### PR TITLE
Order of arguments integrate func

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -51,6 +51,8 @@ The following features will be implemented in future versions of pySODM,
 
 - Currently, a *time-dependent parameter function* takes only the parameter to be varied `param` as an input. Perhaps the entire parameter dictionary should be given instead for more flexibility?
 
+- Currently, a parameter can only have one *time-depedent parameter function*. Perhaps a list containing multiple function can be supplied? A workaround is to split the parameter in two parameters and multiply them in the integrate function. Very low priority.
+
 ### Versions
 
 - version 0.1 (2022-12-23) 

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,6 +1,6 @@
 # Models
 
-Standard usage of pySODM involves building an ODE or SDE model. For practical examples of initializing models, we refer to the [tutorials](workflow.md).
+Standard usage of pySODM involves building an ODE or SDE model. For practical examples of initializing models, we refer to the [tutorials](quickstart.md).
 
 ## base.py
 
@@ -12,7 +12,7 @@ The ODEModel class inherits several attributes from the model class defined by t
 
 * **state_names** (list) - Contains the names (type: str) of the states.
 * **parameter_names** (list) - Contains the names (type: str) of the non-stratified parameters. Non-stratified parameters are not subject to input checks and can thus be of any datatype/size.
-* **integrate** (function) - Function to compute the differentials of every model state. The integrate function must have the timestep `t` as its first input, followed by the `state_names`, then the `parameter_names` and then the `parameter_stratified_names`, all in the correct order. The integrate function must return a differential for every model state of the correct size and in the same order as `state_names`. The integrate function must be a static method (include `@staticmethod`).
+* **integrate** (function) - Function to compute the differentials of every model state. The integrate function must have the timestep `t` as its first input, followed by the `state_names`, `parameter_names` and `parameter_stratified_names` (their order is not important). The integrate function must return a differential for every model state of the correct size and **in the same order as `state_names`**. The integrate function must be a static method (include `@staticmethod`).
 * **stratification_names** (list) - optional - Contains the names of the stratification axes. The names given here become the dimensions in the simulation output `xarray` Dataset.
 * **parameter_stratified_names** (list) - optional - Contains the names of the stratified parameters. Stratified parameters are subject to input checks. They must be a list or a 1D np.ndarray with a length equal to the number of coordinates of the stratification axis. 
     * For one stratification axes: list contains strings - `['stratpar_1', 'stratpar_2']`
@@ -58,7 +58,7 @@ The SDEModel class inherits several attributes from the model class defined by t
 
 * **state_names** (list) - Contains the names (type: str) of the states.
 * **parameter_names** (list) - Contains the names (type: str) of the non-stratified parameters. Non-stratified parameters are not subject to input checks and can thus be of any datatype/size.
-* **compute_rates** (function) - Function returning the rates of transitioning between the model states. `compute_rates()` must have the timestep `t` as its first input, followed by the `state_names`, then the `parameter_names` and then the `parameter_stratified_names`, all in the correct order. `compute_rates()` must be a static method (include `@staticmethod`). The output of `compute_rates()` must be a dictionary. Its keys must be valid model states, a rate is only needed for the states undergoing a transitioning. The corresponding values must be a list containing the rates of the possible transitionings of the state. In this way, a model state can have multiple transitionings.
+* **compute_rates** (function) - Function returning the rates of transitioning between the model states. `compute_rates()` must have the timestep `t` as its first input, followed by the `state_names`, `parameter_names` and the `parameter_stratified_names` (their order is not important). `compute_rates()` must be a static method (include `@staticmethod`). The output of `compute_rates()` must be a dictionary. Its keys must be valid model states, a rate is only needed for the states undergoing a transitioning. The corresponding values must be a list containing the rates of the possible transitionings of the state. In this way, a model state can have multiple transitionings.
 * **apply_transitionings** (function) - Function to update the states with the number of drawn transitionings. `apply_transitionings()` must have the timestep `t` as its first input, followed by the solver timestep `tau`, follwed by the dictionary containing the transitionings `transitionings`, then followed by the model states and parameters similarily to `compute_rates()`.
 * **stratification_names** (list) - optional - Contains the names of the stratification axes. The names given here become the dimensions in the simulation output `xarray` Dataset.
 * **parameter_stratified_names** (list) - optional - Contains the names of the stratified parameters. Stratified parameters are subject to input checks. They must be a list or a 1D np.ndarray with a length equal to the number of coordinates of the stratification axis. 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,10 +40,14 @@ model = SIR(states={'S': 1000, 'I': 1}, parameters={'beta': 0.35, 'gamma': 5})
 Simulate the model using the `sim()` method. The solver method and tolerance, as well as the timesteps in the output can be tailored. pySODM supports the use of `datetime` types as timesteps.
 
 ```python
+# Timesteps
 out = model.sim(121)
+
+# Dates
+out = model.sim(['2022-12-01', '2023-05-01'])
 ```
 
-Results are sent to an `xarray.Dataset`, for more information on indexing and selecting data, [see](https://docs.xarray.dev/en/stable/user-guide/indexing.html).
+Results are sent to an `xarray.Dataset`, for more information on indexing and selecting data using `xarray`, [see](https://docs.xarray.dev/en/stable/user-guide/indexing.html).
 ```bash
 <xarray.Dataset>
 Dimensions:  (time: 122)
@@ -53,9 +57,9 @@ Data variables:
     S        (time) float64 1e+03 999.6 999.2 998.7 ... 287.2 287.2 287.2 287.2
     I        (time) float64 1.0 1.161 1.348 1.565 ... 0.1455 0.1316 0.1192
     R        (time) float64 0.0 0.2157 0.4662 0.7569 ... 713.6 713.7 713.7 713.7
-
-
 ```
+
+![SIR_time](/_static/figs/workflow/SIR_time.png)
 
 ## Stratifications: adding age groups to the SIR model
 
@@ -144,7 +148,7 @@ Data variables:
 
 ### Time-dependent parameter function
 
-Parameters can also be varied through the course of one simulation using a *time-dependent parameter function*, which can be an arbitrarily complex function. A generic time-dependent parameter function has the timestep, the dictionary of model states and the value of the varied parameter as its inputs. Additionally, the function can take any number of arguments.
+Parameters can also be varied through the course of one simulation using a *time-dependent parameter function*, which can be an arbitrarily complex function. A generic time-dependent parameter function has the timestep, the dictionary of model states and the value of the varied parameter as its inputs. Additionally, the function can take any number of arguments (including other model parameters).
 
 ```python
 def vary_my_parameter(t, states, param, an_additional_parameter):

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -83,15 +83,15 @@ or schematically,
 
 <img src="./_static/figs/workflow/flowchart_SIR.png" width="500" />
 
-The model has three states: 1) The number of individuals susceptible to the disease (S), 2) the number of infectious individuals (I), and 3) the number of removed individuals (R). The model has two parameters: 1) `beta`, the rate of transmission and, 2) `gamma`, the duration of infectiousness. Building a model is based on the class inheritance, the user must first load the `ODEModel` or `SDEModel` class from  `~/src/models/base.by`. Then, the user must define his/her own class which must contain (minimally),
+The model has three states: 1) The number of individuals susceptible to the disease (S), 2) the number of infectious individuals (I), and 3) the number of removed individuals (R). The model has two parameters: 1) `beta`, the rate of transmission and, 2) `gamma`, the duration of infectiousness. Building a model is based on the class inheritance, the user must first load the `ODEModel` class from  `~/src/models/base.by`. Then, the user must define his/her own class which must contain (minimally),
 - A list containing the state names `state_names`,
 - A list containing the parameter names `parameter_names`,
 - An `integrate()` function where the differentials of the model are computed,
 
 and take the `ODEModel` class as its input. Checkout the documentation of the ODEModel class [here](models.md). There are some important formatting requirements to the integrate function, which are verified when the model is initialized,
 1. The integrate function must have the timestep `t` as its first input
-2. The timestep `t` is first followed by the states, then the parameters in the correct order
-3. The integrate function must return a differential for every model state
+2. The model states and parameters must also be given as input, their order does not make a difference
+3. The integrate function must return a differential for every model state, arranged in the same order as the state names defined in `state_names`
 4. The integrate function must be a static method (include `@staticmethod`)
 
 ```
@@ -150,29 +150,6 @@ plt.close()
 ```
 
 ![SIR_date](/_static/figs/workflow/SIR_date.png)
-
-The `sim()` method can also be run with timesteps as coordinates of the time axis (int/float). By convention, the name of the time axis in the `xarray` output is equal to `date` when using dates and `time` when using timesteps.
-```
-# Simulate from t=0 until t=121
-out = model.sim([0, 121])
-
-# Is equivalent to:
-out = model.sim(121)
-
-# But now the time axis is named 'time'
-fig,ax=plt.subplots(figsize=(12,4))
-ax.plot(out['time'], out['S'], color='green', label='Susceptible')
-ax.plot(out['time'], out['I'], color='red', label='Infectious')
-ax.plot(out['time'], out['R'], color='black', label='Removed')
-ax.xaxis.set_major_locator(plt.MaxNLocator(3))
-ax.legend()
-plt.show()
-plt.close()
-```
-
-![SIR_time](/_static/figs/workflow/SIR_time.png)
-
-The user can acces the integration methods and relative tolerance of `scipy.solve_ivp()` by supplying the `method` and `rtol` arguments to the [`sim()` function](models.md). The user can determine the output timestep frequency by changing the optional `output_timestep` argument.
 
 ### Calibrating the model
 

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -24,11 +24,11 @@ class SDEModel:
     To initialise the model, provide following inputs:
 
     states : dictionary
-        contains the initial values of all non-zero model states
-        e.g. {'S': N, 'E': np.ones(n_stratification)} with N being the total population and n_stratifications the number of stratified layers
-        initialising zeros is thus not required
+        contains the initial values of all non-zero model states, f.i. for an SEIR model,
+        e.g. {'S': [1000, 1000, 1000], 'E': [1, 1, 1]
+        initialising zeros is not required
     parameters : dictionary
-        containing the values of all parameters (both stratified and not)
+        values of all parameters (both stratified and not)
     time_dependent_parameters : dictionary, optional
         Optionally specify a function for time-dependent parameters. The
         signature of the function should be ``fun(t, states, param, ...)`` taking
@@ -51,6 +51,18 @@ class SDEModel:
         self.parameters = parameters
         self.coordinates = coordinates
         self.time_dependent_parameters = time_dependent_parameters
+
+        # Merge parameter_names and parameter_stratified_names
+        self.parameter_names_merged = merge_parameter_names_parameter_stratified_names(self.parameter_names, self.parameter_stratified_names)
+
+        # Duplicates in lists containing names of states/parameters/stratified parameters/stratifications?
+        check_duplicates(self.state_names, 'state_names')
+        try:
+            check_duplicates(self.parameter_names_merged, 'parameter_names + parameter_stratified_names')
+        except:
+            check_duplicates(self.parameter_names, 'parameter_names')
+        if self.stratification_names:
+            check_duplicates(self.stratification_names, 'stratification_names')
 
         # Validate and compute the stratification sizes
         self.stratification_size = validate_stratifications(self.stratification_names, self.coordinates)
@@ -270,20 +282,17 @@ class SDEModel:
                         func_params = {key: params[key] for key in self._function_parameters[i]}
                         params[param] = param_func(date, states, pars[param], **func_params)
 
-                # ----------------------------------
-                # construct list of model parameters
-                # ----------------------------------
+                # -------------------------------------------------------------
+                #  throw parameters of TDPFs out of model parameters dictionary
+                # -------------------------------------------------------------
 
-                if self._n_function_params > 0:
-                    model_pars = list(params.values())[:-self._n_function_params]
-                else:
-                    model_pars = list(params.values())
+                params = {k:v for k,v in params.items() if ((k not in self._extra_params) or (k in self.parameter_names_merged))}
 
                 # -------------
                 # compute rates
                 # -------------
 
-                rates = self.compute_rates(t, *y_reshaped, *model_pars)
+                rates = self.compute_rates(t, **states, **params)
 
                 # --------------
                 # Gillespie step
@@ -298,7 +307,7 @@ class SDEModel:
                 # update states 
                 # -------------
 
-                dstates = self.apply_transitionings(t, tau, transitionings, *y_reshaped, *model_pars)
+                dstates = self.apply_transitionings(t, tau, transitionings, **states, **params)
 
                 return np.array(dstates).flatten(), tau
 
@@ -572,13 +581,13 @@ class ODEModel:
                 for size in self.stratification_size:
                     size_lst.append(size)
                 y_reshaped = y.reshape(tuple(size_lst))
-                state_params = dict(zip(self.state_names, y_reshaped))
+                states = dict(zip(self.state_names, y_reshaped))
             else:
                 # incoming y -> different reshape for 1D vs 2D variables  (2)
                 y_1d, y_2d = np.split(y, [self.split_point])
                 y_1d = y_1d.reshape(((len(self.state_names) - 1), self.stratification_size[0]))
                 y_2d = y_2d.reshape((self.stratification_size[0], self.stratification_size[0]))
-                state_params  = dict(zip(self.state_names, [y_1d,y_2d]))
+                states  = dict(zip(self.state_names, [y_1d,y_2d]))
 
             # --------------------------------------
             # update time-dependent parameter values
@@ -593,7 +602,7 @@ class ODEModel:
                     date = t
                 for i, (param, param_func) in enumerate(self.time_dependent_parameters.items()):
                     func_params = {key: params[key] for key in self._function_parameters[i]}
-                    params[param] = param_func(date, state_params, pars[param], **func_params)
+                    params[param] = param_func(date, states, pars[param], **func_params)
 
             # -------------------------------------------------------------
             #  throw parameters of TDPFs out of model parameters dictionary
@@ -606,7 +615,7 @@ class ODEModel:
             # -------------------
 
             if not self.state_2d:
-                dstates = self.integrate(t, **state_params, **params)
+                dstates = self.integrate(t, **states, **params)
                 return np.array(dstates).flatten()
             else:
                 dstates = self.integrate(t, *y_1d, y_2d, **params)

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -13,7 +13,7 @@ import multiprocessing as mp
 from functools import partial
 from scipy.integrate import solve_ivp
 from pySODM.models.utils import int_to_date
-from pySODM.models.validation import validate_draw_function, validate_simulation_time, validate_stratifications, validate_time_dependent_parameters, validate_ODEModel, validate_SDEModel
+from pySODM.models.validation import validate_draw_function, validate_simulation_time, validate_stratifications, validate_time_dependent_parameters, validate_ODEModel, validate_SDEModel, check_duplicates
 
 class SDEModel:
     """
@@ -517,6 +517,15 @@ class ODEModel:
         self.parameters = parameters
         self.coordinates = coordinates
         self.time_dependent_parameters = time_dependent_parameters
+
+        # Duplicates in lists containing names of states/parameters/stratifications?
+        # TODO: stratified parameters?
+        check_duplicates(self.state_names, 'state_names')
+        check_duplicates(self.parameter_names, 'parameter_names')
+        if self.stratification_names:
+            check_duplicates(self.stratification_names, 'stratification_names')
+        if self.state_2d:
+            check_duplicates(self.state_2d, 'state_2d')
 
         # Validate and compute the stratification sizes
         self.stratification_size = validate_stratifications(self.stratification_names, self.coordinates)

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -442,7 +442,7 @@ def validate_SDEModel(initial_states, parameters, coordinates, stratification_si
             "Redundant: {2}. ".format(missing_parameters, missing_states, list(redundant_all))
         )
     # Save a copy to validate the model later on
-    parameters_wo_TDPF_pars = {param: parameters[param] for param in specified_params}
+    specified_params_wo_TDPF_pars = specified_params.copy()
     # additional parameters from time-dependent parameter functions
     # are added to specified_params after the above check
     if _function_parameters:
@@ -618,7 +618,8 @@ def validate_SDEModel(initial_states, parameters, coordinates, stratification_si
 
     # compute_rates
     # ~~~~~~~~~~~~~
-
+    # TODO: Throw out _extra_params here
+    parameters_wo_TDPF_pars = {param: parameters[param] for param in specified_params_wo_TDPF_pars}
     # Call the function with initial values to check if the function returns the right format of dictionary
     rates = compute_rates_func(10, **initial_states, **parameters_wo_TDPF_pars)
     # Check if a dictionary is returned

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -242,6 +242,21 @@ def check_duplicates(lst, name):
             f"List '{name}' contains duplicates: {dupes}"
         )
 
+def merge_parameter_names_parameter_stratified_names(parameter_names, parameter_stratified_names):
+    """ A function to merge the 'parameter_names' and 'parameter_stratified_names' lists"""
+    merged_params = parameter_names.copy()
+    if parameter_stratified_names:
+        if not isinstance(parameter_stratified_names[0], list):
+            if len(parameter_stratified_names) == 1:
+                merged_params += parameter_stratified_names
+            else:
+                for stratified_names in parameter_stratified_names:
+                    merged_params += [stratified_names,]
+        else:
+            for stratified_names in parameter_stratified_names:
+                merged_params += stratified_names
+    return merged_params
+
 def validate_ODEModel(initial_states, parameters, coordinates, stratification_size, state_names, parameter_names,
                         parameters_stratified_names, _function_parameters, _create_fun, integrate_func, state_2d=None):
     """
@@ -302,12 +317,12 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
         # Remove duplicate arguments in time dependent parameter functions
         _extra_params = OrderedDict((x, True) for x in _extra_params).keys()
         # Check if TDPF has a parameter already specified in the model
-        if list(set(_extra_params) & set(specified_params)):
-            raise ValueError(
-                f"The parameters {list(set(_extra_params) & set(specified_params))} are used both in a time-dependent parameter function and in the integrate function. "
-            )
-        else:
-            specified_params += _extra_params
+        #if list(set(_extra_params) & set(specified_params)):
+        #    raise ValueError(
+        #        f"The parameters {list(set(_extra_params) & set(specified_params))} are used both in a time-dependent parameter function and in the integrate function. "
+        #    )
+        #else:
+        specified_params += _extra_params
         len_before = len(specified_params)
         # Line below removes duplicate arguments with integrate defenition
         specified_params = OrderedDict((x, True) for x in specified_params).keys()

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -261,7 +261,7 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
     else:
         start_index = 1
 
-    # Get names of states and parameters that follow after 't' or 't' and 'l'
+    # Get names of states and parameters that follow after 't' 
     N_states = len(state_names)
     integrate_states = keywords[start_index : start_index + N_states]
     if integrate_states != state_names:
@@ -294,21 +294,22 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
     # are added to specified_params after the above check
 
     if _function_parameters:
-        extra_params = [item for sublist in _function_parameters for item in sublist]
+        _extra_params = [item for sublist in _function_parameters for item in sublist]
 
         # TODO check that it doesn't duplicate any existing parameter (completed?)
         # Line below removes duplicate arguments in time dependent parameter functions
-        extra_params = OrderedDict((x, True) for x in extra_params).keys()
-        specified_params += extra_params
+        _extra_params = OrderedDict((x, True) for x in _extra_params).keys()
+        specified_params += _extra_params
         len_before = len(specified_params)
         # Line below removes duplicate arguments with integrate defenition
         specified_params = OrderedDict((x, True) for x in specified_params).keys()
         len_after = len(specified_params)
         # Line below computes number of integrate arguments used in time dependent parameter functions
         n_duplicates = len_before - len_after
-        _n_function_params = len(extra_params) - n_duplicates
+        _n_function_params = len(_extra_params) - n_duplicates
     else:
         _n_function_params = 0
+        _extra_params = []
 
     # Validate the params
     if set(parameters.keys()) != set(specified_params):
@@ -389,7 +390,7 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
                 "The return value of the integrate function does not have the correct length."
             )
     
-    return initial_states, parameters, _n_function_params
+    return initial_states, parameters, _n_function_params, list(_extra_params)
 
 def validate_SDEModel(initial_states, parameters, coordinates, stratification_size, state_names, parameter_names,
                         parameters_stratified_names, _function_parameters, compute_rates_func, apply_transitionings_func):
@@ -458,21 +459,22 @@ def validate_SDEModel(initial_states, parameters, coordinates, stratification_si
     # are added to specified_params after the above check
 
     if _function_parameters:
-        extra_params = [item for sublist in _function_parameters for item in sublist]
+        _extra_params = [item for sublist in _function_parameters for item in sublist]
 
         # TODO check that it doesn't duplicate any existing parameter (completed?)
         # Line below removes duplicate arguments in time dependent parameter functions
-        extra_params = OrderedDict((x, True) for x in extra_params).keys()
-        specified_params += extra_params
+        _extra_params = OrderedDict((x, True) for x in _extra_params).keys()
+        specified_params += _extra_params
         len_before = len(specified_params)
         # Line below removes duplicate arguments with integrate defenition
         specified_params = OrderedDict((x, True) for x in specified_params).keys()
         len_after = len(specified_params)
         # Line below computes number of integrate arguments used in time dependent parameter functions
         n_duplicates = len_before - len_after
-        _n_function_params = len(extra_params) - n_duplicates
+        _n_function_params = len(_extra_params) - n_duplicates
     else:
         _n_function_params = 0
+        _extra_params = []
 
     # Validate the params
     if set(parameters.keys()) != set(specified_params):
@@ -538,21 +540,22 @@ def validate_SDEModel(initial_states, parameters, coordinates, stratification_si
     # are added to specified_params after the above check
 
     if _function_parameters:
-        extra_params = [item for sublist in _function_parameters for item in sublist]
+        _extra_params = [item for sublist in _function_parameters for item in sublist]
 
         # TODO check that it doesn't duplicate any existing parameter (completed?)
         # Line below removes duplicate arguments in time dependent parameter functions
-        extra_params = OrderedDict((x, True) for x in extra_params).keys()
-        specified_params += extra_params
+        _extra_params = OrderedDict((x, True) for x in _extra_params).keys()
+        specified_params += _extra_params
         len_before = len(specified_params)
         # Line below removes duplicate arguments with integrate defenition
         specified_params = OrderedDict((x, True) for x in specified_params).keys()
         len_after = len(specified_params)
         # Line below computes number of integrate arguments used in time dependent parameter functions
         n_duplicates = len_before - len_after
-        _n_function_params = len(extra_params) - n_duplicates
+        _n_function_params = len(_extra_params) - n_duplicates
     else:
         _n_function_params = 0
+        _extra_params = []
 
     # Validate the params
     if set(parameters.keys()) != set(specified_params):
@@ -687,4 +690,4 @@ def validate_SDEModel(initial_states, parameters, coordinates, stratification_si
     # Reset initial states
     initial_states={k: v[:] for k, v in initial_states_copy.items()}
 
-    return initial_states, parameters, _n_function_params
+    return initial_states, parameters, _n_function_params, list(_extra_params)

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -269,10 +269,7 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
 
     2) Validation of the actual initialization with initial values for the
     states and parameter values.
-    TODO: For now, we require that those are passed in the exact same
-    order, but this requirement could in principle be relaxed, if we ensure
-    to pass the states and parameters as keyword arguments and not as
-    positional arguments to the `integrate` function.
+
     """
 
     # Validate Model class definition (the integrate function)
@@ -284,18 +281,6 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
             "The first argument of the integrate function should always be 't'"
         )
     # Add parameters and stratified parameters to one list: specified_params
-    # specified_params = parameter_names.copy()
-    # if parameter_stratified_names:
-    #     if not isinstance(parameter_stratified_names[0], list):
-    #         if len(parameter_stratified_names) == 1:
-    #             specified_params += parameter_stratified_names
-    #         else:
-    #             for stratified_names in parameter_stratified_names:
-    #                 specified_params += [stratified_names,]
-    #     else:
-    #         for stratified_names in parameter_stratified_names:
-    #             specified_params += stratified_names
-
     specified_params = merge_parameter_names_parameter_stratified_names(parameter_names, parameter_stratified_names)
     # Check if all the states and parameters are present
     if set(specified_params + state_names) != set(keywords[1:]):
@@ -318,12 +303,6 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
         _extra_params = [item for sublist in _function_parameters for item in sublist]
         # Remove duplicate arguments in time dependent parameter functions
         _extra_params = OrderedDict((x, True) for x in _extra_params).keys()
-        # Check if TDPF has a parameter already specified in the model
-        #if list(set(_extra_params) & set(specified_params)):
-        #    raise ValueError(
-        #        f"The parameters {list(set(_extra_params) & set(specified_params))} are used both in a time-dependent parameter function and in the integrate function. "
-        #    )
-        #else:
         specified_params += _extra_params
         len_before = len(specified_params)
         # Line below removes duplicate arguments with integrate defenition

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -233,6 +233,15 @@ def validate_stratified_parameters(values, name, object_name,i,stratification_si
             )
         )
 
+def check_duplicates(lst, name):
+    """A function raising an error if lst contains duplicates"""
+    seen = set()
+    dupes = [x for x in lst if x in seen or seen.add(x)]
+    if dupes:
+        raise ValueError(
+            f"List '{name}' contains duplicates: {dupes}"
+        )
+
 def validate_ODEModel(initial_states, parameters, coordinates, stratification_size, state_names, parameter_names,
                         parameters_stratified_names, _function_parameters, _create_fun, integrate_func, state_2d=None):
     """
@@ -292,7 +301,13 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
         _extra_params = [item for sublist in _function_parameters for item in sublist]
         # Remove duplicate arguments in time dependent parameter functions
         _extra_params = OrderedDict((x, True) for x in _extra_params).keys()
-        specified_params += _extra_params
+        # Check if TDPF has a parameter already specified in the model
+        if list(set(_extra_params) & set(specified_params)):
+            raise ValueError(
+                f"The parameters {list(set(_extra_params) & set(specified_params))} are used both in a time-dependent parameter function and in the integrate function. "
+            )
+        else:
+            specified_params += _extra_params
         len_before = len(specified_params)
         # Line below removes duplicate arguments with integrate defenition
         specified_params = OrderedDict((x, True) for x in specified_params).keys()

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -136,16 +136,16 @@ def validate_parameter_function(func):
     else:
         return keywords[3:]
 
-def validate_time_dependent_parameters(parameter_names, parameters_stratified_names,time_dependent_parameters):
+def validate_time_dependent_parameters(parameter_names, parameter_stratified_names,time_dependent_parameters):
 
     extra_params = []
     all_param_names = parameter_names.copy()
 
-    if parameters_stratified_names:
-        if not isinstance(parameters_stratified_names[0], list):
-            all_param_names += parameters_stratified_names
+    if parameter_stratified_names:
+        if not isinstance(parameter_stratified_names[0], list):
+            all_param_names += parameter_stratified_names
         else:
-            for lst in parameters_stratified_names:
+            for lst in parameter_stratified_names:
                 all_param_names.extend(lst)
             
     for param, func in time_dependent_parameters.items():
@@ -258,7 +258,7 @@ def merge_parameter_names_parameter_stratified_names(parameter_names, parameter_
     return merged_params
 
 def validate_ODEModel(initial_states, parameters, coordinates, stratification_size, state_names, parameter_names,
-                        parameters_stratified_names, _function_parameters, _create_fun, integrate_func, state_2d=None):
+                        parameter_stratified_names, _function_parameters, _create_fun, integrate_func, state_2d=None):
     """
     This does some basic validation of the model + initialization:
 
@@ -284,17 +284,19 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
             "The first argument of the integrate function should always be 't'"
         )
     # Add parameters and stratified parameters to one list: specified_params
-    specified_params = parameter_names.copy()
-    if parameters_stratified_names:
-        if not isinstance(parameters_stratified_names[0], list):
-            if len(parameters_stratified_names) == 1:
-                specified_params += parameters_stratified_names
-            else:
-                for stratified_names in parameters_stratified_names:
-                    specified_params += [stratified_names,]
-        else:
-            for stratified_names in parameters_stratified_names:
-                specified_params += stratified_names
+    # specified_params = parameter_names.copy()
+    # if parameter_stratified_names:
+    #     if not isinstance(parameter_stratified_names[0], list):
+    #         if len(parameter_stratified_names) == 1:
+    #             specified_params += parameter_stratified_names
+    #         else:
+    #             for stratified_names in parameter_stratified_names:
+    #                 specified_params += [stratified_names,]
+    #     else:
+    #         for stratified_names in parameter_stratified_names:
+    #             specified_params += stratified_names
+
+    specified_params = merge_parameter_names_parameter_stratified_names(parameter_names, parameter_stratified_names)
     # Check if all the states and parameters are present
     if set(specified_params + state_names) != set(keywords[1:]):
         # Extract redundant and missing parameters
@@ -352,23 +354,23 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
             )
 
     # the size of the stratified parameters
-    if parameters_stratified_names:
+    if parameter_stratified_names:
         i = 0
-        if not isinstance(parameters_stratified_names[0], list):
-            if len(parameters_stratified_names) == 1:
-                for param in parameters_stratified_names:
+        if not isinstance(parameter_stratified_names[0], list):
+            if len(parameter_stratified_names) == 1:
+                for param in parameter_stratified_names:
                     validate_stratified_parameters(
                             parameters[param], param, "stratified parameter",i,stratification_size,coordinates
                         )
                 i = i + 1
             else:
-                for param in parameters_stratified_names:
+                for param in parameter_stratified_names:
                     validate_stratified_parameters(
                             parameters[param], param, "stratified parameter",i,stratification_size,coordinates
                         )
                 i = i + 1
         else:
-            for stratified_names in parameters_stratified_names:
+            for stratified_names in parameter_stratified_names:
                 for param in stratified_names:
                     validate_stratified_parameters(
                         parameters[param], param, "stratified parameter",i,stratification_size,coordinates
@@ -416,7 +418,7 @@ def validate_ODEModel(initial_states, parameters, coordinates, stratification_si
     return initial_states, parameters, _n_function_params, list(_extra_params)
 
 def validate_SDEModel(initial_states, parameters, coordinates, stratification_size, state_names, parameter_names,
-                        parameters_stratified_names, _function_parameters, compute_rates_func, apply_transitionings_func):
+                        parameter_stratified_names, _function_parameters, compute_rates_func, apply_transitionings_func):
     """
     This does some basic validation of the model + initialization:
 
@@ -460,21 +462,21 @@ def validate_SDEModel(initial_states, parameters, coordinates, stratification_si
     compute_rates_params = keywords[start_index + N_states :]
     specified_params = parameter_names.copy()
 
-    if parameters_stratified_names:
-        if not isinstance(parameters_stratified_names[0], list):
-            if len(parameters_stratified_names) == 1:
-                specified_params += parameters_stratified_names
+    if parameter_stratified_names:
+        if not isinstance(parameter_stratified_names[0], list):
+            if len(parameter_stratified_names) == 1:
+                specified_params += parameter_stratified_names
             else:
-                for stratified_names in parameters_stratified_names:
+                for stratified_names in parameter_stratified_names:
                     specified_params += [stratified_names,]
         else:
-            for stratified_names in parameters_stratified_names:
+            for stratified_names in parameter_stratified_names:
                 specified_params += stratified_names
 
     if compute_rates_params != specified_params:
         raise ValueError(
             "The parameters in the 'compute_rates' function definition do not match "
-            "the provided 'parameter_names' + 'parameters_stratified_names': "
+            "the provided 'parameter_names' + 'parameter_stratified_names': "
             "{0} vs {1}".format(compute_rates_params, specified_params)
         )
 
@@ -541,21 +543,21 @@ def validate_SDEModel(initial_states, parameters, coordinates, stratification_si
     apply_transitionings_params = keywords[start_index + N_states :]
     specified_params = parameter_names.copy()
 
-    if parameters_stratified_names:
-        if not isinstance(parameters_stratified_names[0], list):
-            if len(parameters_stratified_names) == 1:
-                specified_params += parameters_stratified_names
+    if parameter_stratified_names:
+        if not isinstance(parameter_stratified_names[0], list):
+            if len(parameter_stratified_names) == 1:
+                specified_params += parameter_stratified_names
             else:
-                for stratified_names in parameters_stratified_names:
+                for stratified_names in parameter_stratified_names:
                     specified_params += [stratified_names,]
         else:
-            for stratified_names in parameters_stratified_names:
+            for stratified_names in parameter_stratified_names:
                 specified_params += stratified_names
 
     if apply_transitionings_params != specified_params:
         raise ValueError(
             "The parameters in the 'apply_transitionings' function definition do not match "
-            "the provided 'parameter_names' + 'parameters_stratified_names': "
+            "the provided 'parameter_names' + 'parameter_stratified_names': "
             "{0} vs {1}".format(apply_transitionings_params, specified_params)
         )
 
@@ -610,23 +612,23 @@ def validate_SDEModel(initial_states, parameters, coordinates, stratification_si
     ###############################################################################
 
     # the size of the stratified parameters
-    if parameters_stratified_names:
+    if parameter_stratified_names:
         i = 0
-        if not isinstance(parameters_stratified_names[0], list):
-            if len(parameters_stratified_names) == 1:
-                for param in parameters_stratified_names:
+        if not isinstance(parameter_stratified_names[0], list):
+            if len(parameter_stratified_names) == 1:
+                for param in parameter_stratified_names:
                     validate_stratified_parameters(
                             parameters[param], param, "stratified parameter",i,stratification_size,coordinates
                         )
                 i = i + 1
             else:
-                for param in parameters_stratified_names:
+                for param in parameter_stratified_names:
                     validate_stratified_parameters(
                             parameters[param], param, "stratified parameter",i,stratification_size,coordinates
                         )
                 i = i + 1
         else:
-            for stratified_names in parameters_stratified_names:
+            for stratified_names in parameter_stratified_names:
                 for param in stratified_names:
                     validate_stratified_parameters(
                         parameters[param], param, "stratified parameter",i,stratification_size,coordinates

--- a/src/tests/test_ODEModel.py
+++ b/src/tests/test_ODEModel.py
@@ -244,7 +244,7 @@ def test_model_stratified_init_validation():
         SIRstratified(initial_states2, parameters, coordinates=coordinates)
 
     # validate model class itself
-    msg = "The parameters in the 'integrate' function definition do not match"
+    msg = "The provided state names and parameters don't match the parameters and states of the integrate function"
     SIRstratified.parameter_names = ["gamma", "alpha"]
     with pytest.raises(ValueError, match=msg):
         SIRstratified(initial_states, parameters, coordinates=coordinates)
@@ -323,9 +323,10 @@ def test_TDPF_stratified():
             return param * gamma
 
     parameters = {"gamma": 0.2, "beta": np.array([0.8, 0.9])}
-    model2 = SIRstratified(initial_states, parameters, coordinates=coordinates,
+    msg="are used both in a time-dependent parameter function and in the integrate function"
+    with pytest.raises(ValueError, match=msg):
+        model2 = SIRstratified(initial_states, parameters, coordinates=coordinates,
                            time_dependent_parameters={'beta': compliance_func})
-    output2 = model2.sim(time)
 
 # TDPF on a regular parameter
 def test_TDPF_nonstratified():

--- a/src/tests/test_ODEModel.py
+++ b/src/tests/test_ODEModel.py
@@ -323,11 +323,11 @@ def test_TDPF_stratified():
             return param * gamma
 
     parameters = {"gamma": 0.2, "beta": np.array([0.8, 0.9])}
-    msg="are used both in a time-dependent parameter function and in the integrate function"
-    with pytest.raises(ValueError, match=msg):
-        model2 = SIRstratified(initial_states, parameters, coordinates=coordinates,
+    #msg="are used both in a time-dependent parameter function and in the integrate function"
+    #with pytest.raises(ValueError, match=msg):
+    model2 = SIRstratified(initial_states, parameters, coordinates=coordinates,
                            time_dependent_parameters={'beta': compliance_func})
-
+    output2 = model2.sim(time)      
 # TDPF on a regular parameter
 def test_TDPF_nonstratified():
     # states, parameters, coordinates

--- a/src/tests/test_SDEModel.py
+++ b/src/tests/test_SDEModel.py
@@ -146,16 +146,16 @@ def test_model_init_validation():
 
     # validate model class itself
     SIR.state_names = ["S", "R"]
-    with pytest.raises(ValueError, match="The states in the 'compute_rates' function definition do not match the provided 'state_names'"):
+    with pytest.raises(ValueError, match="The provided state names and parameters don't match the parameters and states of the compute_rates function."):
         SIR(initial_states, parameters)
 
     SIR.state_names = ["S", "II", "R"]
-    with pytest.raises(ValueError, match="The states in the 'compute_rates' function definition"):
+    with pytest.raises(ValueError, match="The provided state names and parameters don't match the parameters and states of the compute_rates function."):
         SIR(initial_states, parameters)
 
     SIR.state_names = ["S", "I", "R"]
     SIR.parameter_names = ['beta', 'alpha']
-    with pytest.raises(ValueError, match="The parameters in the 'compute_rates' function"):
+    with pytest.raises(ValueError, match="The provided state names and parameters don't match the parameters and states of the compute_rates function."):
         SIR(initial_states, parameters)
 
     # ensure to set back to correct ones
@@ -271,7 +271,7 @@ def test_model_stratified_init_validation():
         SIRstratified(initial_states2, parameters, coordinates=coordinates)
 
     # validate model class itself
-    msg = "The parameters in the 'compute_rates' function definition do not match"
+    msg = "The provided state names and parameters don't match the parameters and states of the"
     SIRstratified.parameter_names = ["gamma", "alpha"]
     with pytest.raises(ValueError, match=msg):
         SIRstratified(initial_states, parameters, coordinates=coordinates)

--- a/tutorials/influenza_1718/calibration.py
+++ b/tutorials/influenza_1718/calibration.py
@@ -54,7 +54,7 @@ initN = pd.Series(index=age_groups, data=np.array([606938, 1328733, 7352492, 220
 ##############
 
 alpha = 0.03 # Overdispersion of data
-N = 20 # Repeated simulations
+N = 10 # Repeated simulations
 start_calibration = start_date 
 end_calibration = pd.Timestamp('2018-03-01')
 identifier = 'twallema_2018-03-01'
@@ -119,7 +119,7 @@ if __name__ == '__main__':
 
     # Variables
     processes = int(os.getenv('SLURM_CPUS_ON_NODE', mp.cpu_count()/2))
-    n_pso = 50
+    n_pso = 20
     multiplier_pso = 20
     # Define dataset
     data=[df_influenza[start_calibration:end_calibration], ]


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

This PR addresses Issue #9: the names of the states and parameters defined by the user in his/her model class had to provided in exactly the same order in the integrate/compute_rates function defined by the user. By providing the parameters and states internally as keyworded arguments to the integrate/compute_rates function, this need has been relaxed.

However, the user should still make sure the differentials of his `integrate` function (for ODEs) match the order of the state names provided. I choose not to return the differentials as a dictionary (for now), as I still have to figure out if using dictionaries with numba is sufficiently easy.
