### PR TITLE
Incorporate pySODM 0.2.0 in COVID-19 code

### DIFF
--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -628,7 +628,7 @@ class ODEModel:
             self.parameters = validate_parameter_stratified_sizes(self.parameter_stratified_names, self.dimension_names, coordinates, self.parameters)
 
         # Call the integrate function, check if it works and check the sizes of the differentials in the output
-        validate_integrate(self.initial_states, self.parameters, self._create_fun, self.state_shapes)
+        validate_integrate(self.initial_states, dict(zip(self.parameter_names_merged,[self.parameters[k] for k in self.parameter_names_merged])), self.integrate, self.state_shapes)
 
     # Overwrite integrate class
     @staticmethod

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -356,7 +356,7 @@ class SDEModel:
                 # Deflatten y and reconstruct dictionary of states 
                 # ------------------------------------------------
 
-                states = list_to_dict(y, self.state_shapes)
+                states = list_to_dict(y, self.state_shapes, retain_floats=False)
 
                 # --------------------------------------
                 # update time-dependent parameter values

--- a/src/pySODM/models/utils.py
+++ b/src/pySODM/models/utils.py
@@ -6,9 +6,10 @@ def int_to_date(actual_start_date, t):
     return date
 
 
-def list_to_dict(y, shape_dictionary):
+def list_to_dict(y, shape_dictionary, retain_floats=True):
     """
-    A function to reconstruct a number of variables of different shapes, given a flat array of values and a dictionary with the variables name and desired shapes
+    A function to reconstruct model states, given a flat array of values and a dictionary with the variables name and desired shapes
+    Retains floats.
 
     Parameters
     ----------
@@ -19,6 +20,9 @@ def list_to_dict(y, shape_dictionary):
     shape_dictionary: dict
         A dictionary containing the desired names and shapes of the output dictionary
     
+    retain_floats: bool
+        If False, float/np.float are converted in a 0D np.ndarray. Default: True.
+
     Returns
     -------
 
@@ -31,7 +35,7 @@ def list_to_dict(y, shape_dictionary):
     for s in shape_dictionary.values():
         n = np.prod(s)
         # Reshape changes type of floats to np.ndarray which is not desirable
-        if n == 1:
+        if ((n == 1) & (retain_floats==True)):
             restoredArray.append(y[offset])
         else:
             restoredArray.append(y[offset:(offset+n)].reshape(s))

--- a/src/pySODM/models/utils.py
+++ b/src/pySODM/models/utils.py
@@ -30,7 +30,11 @@ def list_to_dict(y, shape_dictionary):
     offset=0
     for s in shape_dictionary.values():
         n = np.prod(s)
-        restoredArray.append(y[offset:(offset+n)].reshape(s))
+        # Reshape changes type of floats to np.ndarray which is not desirable
+        if n == 1:
+            restoredArray.append(y[offset])
+        else:
+            restoredArray.append(y[offset:(offset+n)].reshape(s))
         offset+=n
 
     return dict(zip(shape_dictionary.keys(), restoredArray))

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -501,9 +501,9 @@ def validate_integrate(initial_states, parameters, integrate, state_shapes):
             "An error was encountered while calling your integrate function."
         )
     # Flatten initial states
-    y0 = list(itertools.chain(*initial_states.values()))
-    while np.array(y0).ndim > 1:
-        y0 = list(itertools.chain(*y0))
+    y0=[]
+    for v in initial_states.values():
+        y0.extend(list(np.ravel(v)))
     # Assert length equality
     if len(out) != len(y0):
         raise ValueError(

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -485,24 +485,27 @@ def validate_parameter_stratified_sizes(parameter_stratified_names, dimension_na
                                         )
     return parameters
 
-def validate_integrate(initial_states, parameters, _create_fun, state_shapes):
+def validate_integrate(initial_states, parameters, integrate, state_shapes):
     """ Call _create_fun to check if the integrate function (1) works, (2) the differentials have the correct shape
     """
 
-    fun = _create_fun(None)
-    y0 = list(itertools.chain(*initial_states.values()))
-    while np.array(y0).ndim > 1:
-        y0 = list(itertools.chain(*y0))
-    
-    result = fun(1, np.array(y0), parameters)
     try:
-        result = fun(1, np.array(y0), parameters)
+        # Call the integrate function
+        dstates = integrate(1, **initial_states, **parameters)
+        # Flatten
+        out=[]
+        for d in dstates:
+            out.extend(list(np.ravel(d)))
     except:
         raise ValueError(
             "An error was encountered while calling your integrate function."
         )
-
-    if len(result) != len(y0):
+    # Flatten initial states
+    y0 = list(itertools.chain(*initial_states.values()))
+    while np.array(y0).ndim > 1:
+        y0 = list(itertools.chain(*y0))
+    # Assert length equality
+    if len(out) != len(y0):
         raise ValueError(
             "The total length of the differentials returned by your `integrate()` function do not appear to have the correct length. "
             "Verify the differentials are in the same order as `state_names`. Verify every differential has the same size as the state it corresponds to. "


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

I wrote a very long PR and then sadly lost it at the end. I'm gonna be a bit briefer.

I tested the models used in UGentBiomath/COVID-19Model with pySODM version 0.2.0 and found (and solved) three bugs. First, the flattening of the initial states in `base.py` was not correct if states had more than one dimension. Second, the function `list_to_dict` converted all `float` type model states to type `np.ndarray` and this led to unexpected behaviors. However, this conversion is also desired in one case. Thus, I implemented a flag to switch between these behaviours. Third, the validation of the `integrate` function actually tested the scipy-wrapper `func` and this led to some undesired behaviours.