### PR TITLE
Perform better checks on bounds before optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The [enzyme kinetics](enzyme_kinetics.md) and [influenza 17-18](influenza_1718.m
 
 - Version 0.2.0 (2023-01-19, PR #25)
     > Introduction of `state_dimensions` in model declaration, allowing the user to define models where states can have different sizes.
+    - Version 0.2.1 (2023-01-27, PR #30)
+        > Fixed bugs when using pySODM for the COVID-19 related models. More thorough checks on `bounds` in the log posterior probability function. Finished manuscript.
 - Version 0.1 (2022-12-23, PR #14)
     > Application pySODM to three use cases. Documentation website. Unit tests for ODEModel, SDEModel and calibration. 
     - Version 0.1.1 (2023-01-09, PR #20)

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -10,7 +10,7 @@
 
 * **model** (object) - An initialized ODEModel or SDEModel.
 * **parameter_names** (list) - Names of model parameters (type: str) to calibrate. Model parameters must be of type float (0D), list containing float (1D), or np.ndarray (nD).
-* **bounds** (list) - Lower and upper bound of calibrated parameters provided as tuples. `[(lb_1, ub_1), ..., (lb_n, ub_n)]` 
+* **bounds** (list) - Lower and upper bound of calibrated parameters provided as lists/tuples containing lower and upper bound: example: `[(lb_1, ub_1), ..., (lb_n, ub_n)]`. Values falling outside these bounds will be restricted to the provided ranges before simulating the model.
 * **data** (list) - Contains the datasets (type: pd.Series/pd.DataFrame) the model should be calibrated to. For one dataset use `[dataset,]`. Must contain a time index named `time` or `date`. Additional axes must be implemented using a `pd.Multiindex` and must bear the names/contain the coordinates of a valid model dimension.
 * **states** (list) - Names of the model states (type: str) the respective datasets should be matched to.
 * **log_likelihood_fnc** (list) - Contains a log likelihood function for every provided dataset.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='pySODM',
     packages=find_packages("src", exclude=["*.tests"]),
     package_dir={'': 'src'},
-    version='0.2.0',
+    version='0.2.1',
     description='Simulating and Optimising Dynamical Models',
     author='Tijs Alleman, KERMIT, Ghent University',
     license='MIT',

--- a/src/pySODM/optimization/nelder_mead.py
+++ b/src/pySODM/optimization/nelder_mead.py
@@ -52,7 +52,7 @@ def optimize(func, x_start, step,
             bounds = func.expanded_bounds
         except:
             raise Exception(
-                "Variable 'expanded_bounds' not found in object 'func'. Provide bounds directly to `pso.optimize()`. "
+                "'func' does not appear to be a pySODM model: 'expanded_bounds' not found. Provide bounds directly to `pso.optimize()`"
             )
 
     # Input check bounds
@@ -73,7 +73,7 @@ def optimize(func, x_start, step,
     # Check length of x_start
     assert len(x_start) == len(bounds), 'Length of starting estimate must be equal to the provided number of bounds'
 
-    # Checl length of step
+    # Check length of step
     assert len(x_start) == len(step), "Length of 'steps' must equal the number of parameters"
 
     # Construct objective function wrapper

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -439,6 +439,14 @@ class log_posterior_probability():
         This function manages the internal bookkeeping (assignment of model parameters, model simulation) and then computes and sums the log prior probabilities and log likelihoods to compute the log posterior probability.
         """
 
+        # Validate no thetas are out of bounds
+        # Prior to this, it must be validated that lower_bounds < upper_bound
+        for i,theta in enumerate(thetas):
+            if theta > self.expanded_bounds[i][1]:
+                thetas[i] = self.expanded_bounds[i][1]
+            elif theta < self.expanded_bounds[i][0]:
+                thetas[i] = self.expanded_bounds[i][0]
+
         # Unflatten thetas
         thetas_dict = list_to_dict(thetas, self.parameter_shapes)
 
@@ -456,7 +464,6 @@ class log_posterior_probability():
         if not self.initial_states:
             # Perform simulation only once
             out = self.model.sim([self.start_sim,self.end_sim], **simulation_kwargs)
-
             # Loop over dataframes
             for idx,df in enumerate(self.data):
                 # Get aggregation function

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -310,14 +310,14 @@ class log_posterior_probability():
         ## Construct expanded bounds, pars and labels ##
         ################################################
 
-        # Incorporate a test here to check if lower_bounds < upper_bounds
-
         # Expand parameter names 
         self.parameter_names_postprocessing = expand_parameter_names(self.parameter_shapes)
         # Expand bounds
         if len(bounds) == len(parameter_names):
+            check_bounds(bounds)
             self.expanded_bounds = expand_bounds(parameter_sizes, bounds)
         elif len(bounds) == sum(parameter_sizes.values()):
+            check_bounds(bounds)
             self.expanded_bounds = bounds
         else:
             raise Exception(
@@ -441,7 +441,7 @@ class log_posterior_probability():
         This function manages the internal bookkeeping (assignment of model parameters, model simulation) and then computes and sums the log prior probabilities and log likelihoods to compute the log posterior probability.
         """
 
-        # Validate no thetas are out of bounds
+        # Restrict thetas to user-provided bounds
         for i,theta in enumerate(thetas):
             if theta > self.expanded_bounds[i][1]:
                 thetas[i] = self.expanded_bounds[i][1]
@@ -657,8 +657,21 @@ def expand_parameter_names(parameter_shapes):
                 expanded_names.append(n)
     return expanded_names
 
+def check_bounds(bounds):
+    """
+    A function to check the elements in 'bounds': type(list/tuple), length (2), ub > lb
+    """
+    for i,bound in enumerate(bounds):
+        # Check type
+        assert isinstance(bound, (list,tuple)), f'parameter bound (position {i}) is not a list or tuple'
+        # Check length
+        assert len(bound)==2, f'parameter bound (position {i}) contains {len(bound)} entries instead of 2'
+        # Check ub > lb
+        assert bound[0] < bound[1], f'upper-bound value must be greater than lower-bound value (position {i})'
+
 def expand_bounds(parameter_sizes, bounds):
-    """A function to expand the bounds of parameters with multiple entries
+    """"
+    A function to expand the bounds of parameters with multiple elements
     """
     expanded_bounds = []
     for i, name in enumerate(parameter_sizes.keys()):

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -310,6 +310,8 @@ class log_posterior_probability():
         ## Construct expanded bounds, pars and labels ##
         ################################################
 
+        # Incorporate a test here to check if lower_bounds < upper_bounds
+
         # Expand parameter names 
         self.parameter_names_postprocessing = expand_parameter_names(self.parameter_shapes)
         # Expand bounds
@@ -440,7 +442,6 @@ class log_posterior_probability():
         """
 
         # Validate no thetas are out of bounds
-        # Prior to this, it must be validated that lower_bounds < upper_bound
         for i,theta in enumerate(thetas):
             if theta > self.expanded_bounds[i][1]:
                 thetas[i] = self.expanded_bounds[i][1]

--- a/src/pySODM/optimization/pso.py
+++ b/src/pySODM/optimization/pso.py
@@ -92,7 +92,7 @@ def optimize(func, bounds=None, ieqcons=[], f_ieqcons=None, args=(), kwargs={},
             bounds = func.expanded_bounds
         except:
             raise Exception(
-                "Variable 'expanded_bounds' not found in object 'func'. Provide bounds directly to `pso.optimize()`. "
+                "'func' does not appear to be a pySODM model: 'expanded_bounds' not found. Provide bounds directly to `pso.optimize()`"
             )
 
     lb, ub = [], []

--- a/tutorials/influenza_1718/models.py
+++ b/tutorials/influenza_1718/models.py
@@ -42,10 +42,6 @@ class SDE_influenza_model(SDEModel):
     @staticmethod
     def compute_rates(t, S, E, Ia, Im, R, Im_inc, beta, sigma, gamma, N, f_a):
         
-        # Protect model against 'faulty' values of f_a
-        f_a = np.where(f_a < 0, 0, f_a)
-        f_a = np.where(f_a > 1, 1, f_a)
-
         # Calculate total population
         T = S+E+Ia+Im+R
 


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

The user-provided `bounds` for the log posterior probability were only used by pySODM to automatically put uniform priors on the parameters. However, these uniform priors do not contraint the `EnsembleSampler` in proposing moves outside of these bounds. This becomes problematic when a parameter only makes sense in a certain range (f.i. a fraction only making sense on the interval `[0,1]`). If the value of the parameter would be f.i. close to zero, `EnsembleSampler` would certainly propose moves where the fraction is negative and this will cause a stochastically simulated model to crash (probability of transitionings don't add up to one!).

So, from now on, the user-provided bounds restrict the proposals made by the optimization algorithm to the user-provided ranges.

Further, the constituents of `bounds`, i.e. the lists/tuples containing the upper/lower bounds are now checked for their type (list/tuple), length (2) and if upper-bound > lower-bound.

This PR changes the version to 0.2.1. From PR #25 --> PR#30, aside this PR, the manuscript was finished, the COVID-19 models were brought in line with pySODM reveiling three bugs. Next step is easing the installation by publishing to pyPI.