### PR TITLE
Fix transpose additional axes data in log likelihood

### DIFF
--- a/src/pySODM/optimization/mcmc.py
+++ b/src/pySODM/optimization/mcmc.py
@@ -241,6 +241,7 @@ def emcee_sampler_to_dictionary(samples_path, identifier, discard=0, thin=1, run
         print(f'Convergence: the chain is longer than 50 times the intergrated autocorrelation time.\nPreparing to save samples with thinning value {thin}.')
         sys.stdout.flush()
     except:
+        thin=1
         print('Warning: The chain is shorter than 50 times the integrated autocorrelation time.\nUse this estimate with caution and run a longer chain! Setting thinning to 1.\n')
         sys.stdout.flush()
 

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -1080,7 +1080,8 @@ def validate_log_likelihood_function_extra_args(data, n_log_likelihood_extra_arg
                         else:
                             # Make sure time index is in first position
                             val = log_likelihood_fnc_args[idx].to_xarray()
-                            val = val.transpose([time_index,]+additional_axes_data[idx])
+                            dims = [time_index,]+additional_axes_data[idx]
+                            val = val.transpose(*dims)
                             log_likelihood_fnc_args[idx] = val.to_numpy()         
             else:
                 # Compute desired shape in case of one parameter per stratfication
@@ -1108,7 +1109,8 @@ def validate_log_likelihood_function_extra_args(data, n_log_likelihood_extra_arg
                         else:
                             # Make sure time index is in first position
                             val = log_likelihood_fnc_args[idx].to_xarray()
-                            val = val.transpose([time_index,]+additional_axes_data[idx])
+                            dims = [time_index,]+additional_axes_data[idx]
+                            val = val.transpose(*dims)
                             log_likelihood_fnc_args[idx] = val.to_numpy()
     
     return log_likelihood_fnc_args


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

I was trying to calibrate an economic production network model to stratified data (stratified according to the 64 economical activities of the NACE64 classification). To achieve this I am using a Gaussian log-likelihood function with an assumed relative error of 5% on every datapoint (thus the additional argument of the ll_gaussian function is a pd.Series, simply defined as the data multiplied by 5%). This resulted in an error on line 1083 of `objective_functions.py` in pySODM. Here, the dimensions of the noise in our pd.Series are arranged so that the time index is always first. This order must be correct to allow comparison with the model simulations. The `xarray.transpose` method does not take a list as its argument, therefore, 

```python
val = val.transpose([time_index,]+additional_axes_data[idx])
```
was changed into,

```python
dims = [time_index,]+additional_axes_data[idx]
val = val.transpose(*dims)
```
resolving the bug.