### PR TITLE
Solve log_prior_uniform returning -np.inf when optimised value is equal to lower or upper bound

### DIFF
--- a/src/pySODM/optimization/nelder_mead.py
+++ b/src/pySODM/optimization/nelder_mead.py
@@ -52,7 +52,7 @@ def optimize(func, x_start, step,
             bounds = func.expanded_bounds
         except:
             raise Exception(
-                "'func' does not appear to be a pySODM model: 'expanded_bounds' not found. Provide bounds directly to `pso.optimize()`"
+                "'func' does not appear to be a pySODM model: 'expanded_bounds' not found. Provide bounds directly to `nelder_mead.optimize()`"
             )
 
     # Input check bounds

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -130,7 +130,7 @@ def log_prior_uniform(x, bounds):
 
     """
     prob = 1/(bounds[1]-bounds[0])
-    condition = bounds[0] < x < bounds[1]
+    condition = bounds[0] <= x <= bounds[1]
     if condition == True:
         # Can also be set to zero: value doesn't matter much because its constant
         return np.log(prob)


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

If a parameter value proposed by the optimizer was equal to the lower or upper bound provided by the user, then `log_prior_uniform` would return `-np.inf` while this should have been zero.
