### PR TITLE
Raise ValueError if argument `sigma` of `ll_gaussian` <= 0

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -36,7 +36,11 @@ def ll_gaussian(ymodel, ydata, sigma):
     if not sigma.shape == ymodel.shape:
         # Expand first dimensions on 'alpha' to match the axes
         sigma = np.array(sigma)[np.newaxis, ...]   
-
+    # Check for zeros (TODO: move to a higher layer)
+    if len(sigma[sigma<=0]) != 0:
+        raise ValueError(
+            'argument `sigma` of `ll_gaussian` contains values smaller than or equal to zero'
+        )
     return - 1/2 * np.sum((ydata - ymodel) ** 2 / sigma**2 + np.log(2*np.pi*sigma**2))
 
 def ll_poisson(ymodel, ydata):


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

Pretty much what the title implies.
This check should be moved to a higher level in the future.

Handling of absolute/relative/poisson errors should be simplified in a future version in pySODM.
See the following reference on page: Fitting Models to Biological Data using Linear and Nonlinear Regression by HJ Motulsky (2003)
