### PR TITLE
First compute log prior then restrict parameters within bounds

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -445,6 +445,9 @@ class log_posterior_probability():
         This function manages the internal bookkeeping (assignment of model parameters, model simulation) and then computes and sums the log prior probabilities and log likelihoods to compute the log posterior probability.
         """
 
+        # Compute log prior probability 
+        lp = self.compute_log_prior_probability(thetas, self.log_prior_prob_fnc, self.log_prior_prob_fnc_args)
+
         # Restrict thetas to user-provided bounds
         for i,theta in enumerate(thetas):
             if theta > self.expanded_bounds[i][1]:
@@ -462,9 +465,6 @@ class log_posterior_probability():
 
         # Assign model parameters
         self.model.parameters.update(thetas_dict)
-
-        # Compute log prior probability 
-        lp = self.compute_log_prior_probability(thetas, self.log_prior_prob_fnc, self.log_prior_prob_fnc_args)
 
         if not self.initial_states:
             # Perform simulation only once


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

When computing a log posterior probability, the user must supply bounds for every parameters he/she wishes to calibrate. pySODM will, in the `call` function of the `log_posterior_probability` class, physically restrain parameters proposed by the optimization algorithm lying outside these bounds from being supplied to the `sim` method of the model. 

This is done because sometimes parameters are restricted to certain physical ranges (f.i. probabilities must always lie between 0 and 1), and attempting to simulate the model with parameters outside these ranges may result in crashing the model.

The prior probability does not restrict parameters from going outside these bounds.

The restraining of the parameters happened before the computation of the prior probability. This means that if the optimizer proposed a value that was "out of bounds", it would be corrected to fall within the bounds and would then receive no "punishment" from the uniform prior for going outside the bounds. The result is that the optimization algorithm doesn't know that parameters "out of bounds" are to be considered "not okay", represented by a ll score of -np.inf.

I've reversed this sequence (first punishment, then correction) to fix this issue.