### PR TITLE
Make sure dimension 'date' always correponds to axis 0 in pySODM model output 

### DIFF
--- a/src/pySODM/models/utils.py
+++ b/src/pySODM/models/utils.py
@@ -40,5 +40,4 @@ def list_to_dict(y, shape_dictionary, retain_floats=True):
         else:
             restoredArray.append(y[offset:(offset+n)].reshape(s))
         offset+=n
-
     return dict(zip(shape_dictionary.keys(), restoredArray))

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -55,6 +55,11 @@ def validate_simulation_time(time, warmup):
         raise ValueError(
             "Start of simulation is chronologically after end of simulation"
         )
+    elif time[0] == time[1]:
+        # TODO: Might be usefull to just return the initial condition in this case?
+        raise ValueError(
+            "Start of simulation is the same as the end of simulation"
+        )
     return time, actual_start_date
 
 def validate_draw_function(draw_function, parameters, samples):

--- a/src/tests/test_ODEModel.py
+++ b/src/tests/test_ODEModel.py
@@ -35,8 +35,6 @@ def test_SIR_time():
 
     # Do it right
 
-    # Same starttime and stoptime
-    output = model.sim([0,0])
     # Simulate using a mixture of int/float
     time = [int(10), float(50.3)]
     output = model.sim(time)
@@ -60,10 +58,13 @@ def test_SIR_time():
     assert S.shape == (51, )
 
     # Do it wrong
-
     # Start before end
     with pytest.raises(ValueError, match="Start of simulation is chronologically after end of simulation"):
         model.sim([20,5])
+
+    # Start same as end
+    with pytest.raises(ValueError, match="Start of simulation is the same as the end of simulation"):
+        model.sim([0,0])
 
     # Wrong type
     with pytest.raises(TypeError, match="Input argument 'time' must be a"):
@@ -212,9 +213,9 @@ def test_stratified_SIR_output_shape():
     output = model.sim(time)
     # Assert state size
     np.testing.assert_allclose(output["time"], np.arange(0, 51))
-    assert output["S"].values.shape == (2, 51)
-    assert output["I"].values.shape == (2, 51)
-    assert output["R"].values.shape == (2, 51)
+    assert output["S"].values.shape == (51, 2)
+    assert output["I"].values.shape == (51, 2)
+    assert output["R"].values.shape == (51, 2)
 
 def test_stratified_SIR_automatic_filling_initial_states():
     """Validate the initial states not defined are automatically filled with zeros
@@ -345,9 +346,9 @@ def test_SIR_SI_state_shapes():
     output = model.sim([0, 50])
     # Assert state size
     np.testing.assert_allclose(output["time"], np.arange(0, 51))
-    assert output["S"].values.shape == (4, 4, 51)
-    assert output["I"].values.shape == (4, 51)
-    assert output["R"].values.shape == (4, 51)
+    assert output["S"].values.shape == (51, 4, 4)
+    assert output["I"].values.shape == (51, 4)
+    assert output["R"].values.shape == (51, 4)
     assert output["S_v"].values.shape == (51,)
     assert output["I_v"].values.shape == (51,)
 

--- a/src/tests/test_SDEModel.py
+++ b/src/tests/test_SDEModel.py
@@ -37,8 +37,6 @@ def test_SIR_time():
 
     # Do it right
 
-    # Same starttime and stoptime
-    output = model.sim([0,0])
     # Simulate using a mixture of int/float
     time = [int(10), float(50.3)]
     output = model.sim(time)
@@ -62,6 +60,10 @@ def test_SIR_time():
     assert S.shape == (51, )
 
     # Do it wrong
+
+    # Start same as end
+    with pytest.raises(ValueError, match="Start of simulation is the same as the end of simulation"):
+        model.sim([0,0])
 
     # Start before end
     with pytest.raises(ValueError, match="Start of simulation is chronologically after end of simulation"):
@@ -244,9 +246,9 @@ def test_stratified_SIR_output_shape():
     output = model.sim(time)
     # Assert state size
     np.testing.assert_allclose(output["time"], np.arange(0, 51))
-    assert output["S"].values.shape == (2, 51)
-    assert output["I"].values.shape == (2, 51)
-    assert output["R"].values.shape == (2, 51)
+    assert output["S"].values.shape == (51, 2)
+    assert output["I"].values.shape == (51, 2)
+    assert output["R"].values.shape == (51, 2)
 
 def test_stratified_SIR_automatic_filling_initial_states():
     """Validate the initial states not defined are automatically filled with zeros
@@ -383,9 +385,9 @@ def test_SIR_SI_state_shapes():
     output = model.sim([0, 50])
     # Assert state size
     np.testing.assert_allclose(output["time"], np.arange(0, 51))
-    assert output["S"].values.shape == (4, 51)
-    assert output["I"].values.shape == (4, 51)
-    assert output["R"].values.shape == (4, 51)
+    assert output["S"].values.shape == (51, 4)
+    assert output["I"].values.shape == (51, 4)
+    assert output["R"].values.shape == (51, 4)
     assert output["S_v"].values.shape == (51,)
     assert output["I_v"].values.shape == (51,)
 


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In a pySODM simulation result (`xarray`), the first dimension on every data variable should be `time`/`date` by convention. This was previously not the case.