### PR TITLE
Make sure 'date'/'time' is first axis in creation of dummy xarray simulation output in log posterior probability

### DIFF
--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -59,7 +59,6 @@ def _output_to_xarray_dataset(output, state_shapes, state_dimensions, state_coor
     data_variables = list_to_dict(output_flat, new_state_shapes)
     # Move time axis to first position (yes, obviously I have tried this  with np.reshape in `list_to_dict` but this didn't work for n-D states)
     for k,v in data_variables.items():
-        print(k, v)
         data_variables.update({k: np.moveaxis(v, [-1,], [0,])})
 
     # Append the time dimension

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -892,14 +892,14 @@ def create_fake_xarray_output(state_dimensions, state_coordinates, initial_state
     new_state_dimensions={}
     for k,v in state_dimensions.items():
         v_acc = v.copy()
-        v_acc.append(time_index)
+        v_acc = [time_index,] + v_acc
         new_state_dimensions.update({k: v_acc})
 
     # Append the time coordinates
     new_state_coordinates={}
     for k,v in state_coordinates.items():
         v_acc=v.copy()
-        v_acc.append([0,])
+        v_acc = [[0,],] + v_acc
         new_state_coordinates.update({k: v_acc})
 
     # Build the xarray dataset
@@ -907,7 +907,7 @@ def create_fake_xarray_output(state_dimensions, state_coordinates, initial_state
     for var, arr in initial_states.items():
         if arr.ndim >= 1:
             if state_dimensions[var]:
-                arr = arr[..., np.newaxis]
+                arr = arr[np.newaxis, ...]
         xarr = xr.DataArray(arr, dims=new_state_dimensions[var], coords=new_state_coordinates[var])
         data[var] = xarr
 


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

'time'/'date' also has to be first axis in our dummy xarray output created using `create_fake_xarray_output` (relates to PR #41)