### PR TITLE
creat_fake_xarray_output, when using date, index for time should be date

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -899,7 +899,10 @@ def create_fake_xarray_output(state_dimensions, state_coordinates, initial_state
     new_state_coordinates={}
     for k,v in state_coordinates.items():
         v_acc=v.copy()
-        v_acc = [[0,],] + v_acc
+        if time_index == 'time':
+            v_acc = [[0,],] + v_acc
+        elif time_index == 'date':
+            v_acc = [[pd.Timestamp('2000-01-01'),],] + v_acc
         new_state_coordinates.update({k: v_acc})
 
     # Build the xarray dataset
@@ -951,7 +954,6 @@ def compare_data_model_coordinates(output, data, calibration_state_names, aggreg
     for i, (state_name, df) in enumerate(zip(calibration_state_names, data)):
         # Call the aggregation function
         if aggregation_function:
-            
             new_output = aggregation_function[i](output[state_name])
         else:
             new_output = output[state_name]


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In `create_fake_xarray_output`, a "dummy" model output is created for further validation of the objective function. This dummy output was given a `date` or `time` dimension (depending on the `time_index`) with one coordinate: `[0,]`. Thus, even when using `'date'` as time dimension, the coordinate provided in the dummy output was an integer. 

Using an aggregation function that uses some kind of date transformation results in bug. The aggregation function is called with the "dummy" output, which includes only integer timesteps. When the `time_index` is `'date'`, by default, the timestamp '2000-01-01' is used.

