### PR TITLE
Fixed-length discrete time stepper for ODEModels

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -36,7 +36,7 @@ data to compute the posterior probability function, which can subsequently be op
 |                                 | States can be n-dimensional and of different sizes, allowing users to build models with subprocesses                                       |
 |                                 | Allows n-dimensional model states to be labelled with coordinates and dimensions by using `xarray.Dataset}` to store simulation output |
 |                                 | Easy indexing, manipulating, saving, and piping to third-party software of model output by formatting simulation output as `xarray.Dataset` |
-| Simulating the model            | Deterministic (`scipy.integrate`) or stochastic simulation (Gillespie's Stochastic Simulation Algorithm or Tau-Leaping) |
+| Simulating the model            | Continuous and discrete deterministic simulation or discrete stochastic simulation (Gillespie's Stochastic Simulation Algorithm or Tau-Leaping) |
 |                                 | Vary model parameters during the simulation generically using a complex function |
 |                                 | Use *draw functions* to perform repeated simulations for sensitivity analysis. With multiprocessing support |
 | Calibrate the model             | Construct and maximize a posterior probability function  |

--- a/docs/models.md
+++ b/docs/models.md
@@ -30,7 +30,7 @@ Upon intialization of the model class, the following arguments must be provided.
 
 **Methods:**
 
-* **sim(time, N=1, draw_function=None, samples=None, processes=None, method='RK23', rtol=1e-3, output_timestep=1, warmup=0)**
+* **sim(time, N=1, draw_function=None, samples=None, processes=None, method='RK23', rtol=1e-3, tau=None, output_timestep=1, warmup=0)**
 
     Simulate a model over a given time period using `scipy.integrate.solve_ivp()`. Can optionally perform `N` repeated simulations. Can change the values of model parameters at every repeated simulation by drawing samples from a dictionary `samples` using a function `draw_function`.
 
@@ -43,6 +43,7 @@ Upon intialization of the model class, the following arguments must be provided.
     * **processes** - (int) - optional - Number of cores to use when {math}`N > 1`.
     * **method** - (str) - optional - Integration methods of `scipy.integrate.solve_ivp()` (read the [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html)).
     * **rtol** - (int/float) - optional - Relative tolerance of `scipy.integrate.solve_ivp()` (read the [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html)).
+    * **tau** - (int/float) - optional - If `tau != None`, the model is simulated using a simple discrete timestepper with fixed timestep `tau`. Overrides the `method` and `rtol` arguments. 
     * **output_timestep** - (int/float) - optional - Interpolate model output to every `output_timestep` timesteps. For datetimes: expressed in days.
     * **warmup** - (float) - optional - Number of days to simulate prior to the simulation start. Usefull in epidemiological contexts when the time between the appearance of "patient zero" and the collection of data is unkown. 
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,7 +45,7 @@ To initialize the model, provide a dictionary containing the initial values of t
 model = SIR(states={'S': 1000, 'I': 1}, parameters={'beta': 0.35, 'gamma': 5})
 ```
 
-Simulate the model using the `sim()` method. The solver method and tolerance, as well as the timesteps in the output can be tailored. pySODM supports the use of `datetime` types as timesteps.
+Simulate the model using the `sim()` method. The solver method and tolerance of `scipy.solve_ivp()`, as well as the timesteps included in the output can be tailored. pySODM supports the use of `datetime` types as timesteps.
 
 ```python
 # Timesteps
@@ -53,6 +53,19 @@ out = model.sim(121)
 
 # Dates
 out = model.sim(['2022-12-01', '2023-05-01'])
+
+# Tailor method and tolerance of integrator
+out = model.sim(121, method='RK45', rtol='1e-4')
+```
+
+In some situations, the use of a discrete timestep with a fixed length may be preferred, 
+
+```python
+# Use a discrete timestepper with step size 1
+out = model.sim(121, tau=1)
+
+# Is equivalent to (`tau` overwrites `method`!):
+out = model.sim(121, method='RK45', rtol='1e-4', tau=1)
 ```
 
 Results are sent to an `xarray.Dataset`, for more information on indexing and selecting data using `xarray`, [see](https://docs.xarray.dev/en/stable/user-guide/indexing.html).

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -417,7 +417,7 @@ class SDEModel:
 
     def _solve_discrete(self, fun, t_eval, y, args):
         # Preparations
-        y = np.reshape(y, [y.size,1])
+        y = np.reshape(y, [len(y),1])
         y_prev=y
         # Simulation loop
         t_lst=[t_eval[0]]
@@ -425,7 +425,7 @@ class SDEModel:
         while t < t_eval[-1]:
             out, tau = fun(t, y_prev, args)
             y_prev = out
-            out = np.reshape(out,[out.size,1])
+            out = np.reshape(out,[len(out),1])
             y = np.append(y,out,axis=1)
             t = t + tau
             t_lst.append(t)
@@ -720,6 +720,7 @@ class ODEModel:
         y_eval = np.zeros([y.shape[0], len(t_eval)])
         for row_idx in range(y.shape[0]):
             y_eval[row_idx,:] = np.interp(t_eval, t_lst, y[row_idx,:])
+            
         return {'y': y_eval, 't': t_eval}
 
     def _sim_single(self, time, actual_start_date=None, method='RK23', rtol=5e-3, output_timestep=1, tau=None):

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -798,12 +798,18 @@ class ODEModel:
         # Input checks on solver settings
         if not isinstance(rtol, float):
             raise TypeError(
-                "Relative solver tolerance 'rtol' must be of type float"
-            )
+                "relative solver tolerance 'rtol' must be of type float"
+                )
         if not isinstance(method, str):
             raise TypeError(
-                "Solver method 'method' must be of type string"
-            )
+                "solver method 'method' must be of type string"
+                )
+        if tau != None:
+            if not isinstance(tau, (int,float)):
+                raise TypeError(
+                "discrete timestep 'tau' must be of type int or float"
+                )
+            print(f"performing discrete timestepping with tau = {tau}\n")
 
         # Input checks on supplied simulation time
         time, actual_start_date = validate_simulation_time(time, warmup)

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -817,7 +817,7 @@ class ODEModel:
         if tau != None:
             if not isinstance(tau, (int,float)):
                 raise TypeError(
-                "discrete timestep 'tau' must be of type int or float"
+                    "discrete timestep 'tau' must be of type int or float"
                 )
             print(f"performing discrete timestepping with tau = {tau}\n")
 

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -518,10 +518,6 @@ class SDEModel:
         if draw_function:
             validate_draw_function(draw_function, self.parameters, samples)
 
-        # Provinding 'N' but no draw function: wastefull
-        if ((N != 1) & (draw_function==None)):
-            raise ValueError('performing N={0} repeated simulations without a `draw_function` is mighty wastefull of computational resources'.format(N))
-
         # Copy parameter dictionary --> dict is global
         cp = copy.deepcopy(self.parameters)
         # Construct list of drawn dictionaries

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -511,6 +511,16 @@ class SDEModel:
             Simulation output
         """
 
+        # Input checks on solution method and timestep
+        if not isinstance(method, str):
+            raise TypeError(
+                "solver method 'method' must be of type string"
+                )
+        if not isinstance(tau, (int,float)):
+            raise TypeError(
+                "discrete timestep 'tau' must be of type int or float"
+                )
+
         # Input checks on supplied simulation time
         time, actual_start_date = validate_simulation_time(time, warmup)
 

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -243,6 +243,7 @@ def validate_initial_states(state_shapes, initial_states):
     """
     A function to check the types and sizes of the model's initial states provided by the user.
     Automatically assumes non-specified states are equal to zero.
+    All allowed input types converted to np.float64.
 
     Parameters
     ----------
@@ -269,7 +270,7 @@ def validate_initial_states(state_shapes, initial_states):
                                         )
         else:
             # Fill with zeros
-            initial_states[state_name] = np.zeros(state_shape)
+            initial_states[state_name] = np.zeros(state_shape, dtype=np.float64)
 
     # validate the states (using `set` to ignore order)
     if set(initial_states.keys()) != set(state_shapes.keys()):
@@ -283,7 +284,8 @@ def validate_initial_states(state_shapes, initial_states):
     return initial_states
 
 def check_initial_states_shape(values, desired_shape, name, object_name):
-    """A function checking if the provided initial states have the correct shape
+    """ A function checking if the provided initial states have the correct shape
+        Converts all values of initial states to type np.float64
     """
 
     # If the model doesn't have dimensions, initial states can be defined as: np.array([int/float]), [int/float], int or float
@@ -296,7 +298,7 @@ def check_initial_states_shape(values, desired_shape, name, object_name):
         else:
             if isinstance(values,(int,float)):
                 values = np.asarray([values,])
-        values = np.asarray(values)
+        values = np.asarray(values, dtype=np.float64)
 
         if values.shape != desired_shape:
             raise ValueError(
@@ -306,7 +308,7 @@ def check_initial_states_shape(values, desired_shape, name, object_name):
                 )
             )
     else:
-        values = np.asarray(values)
+        values = np.asarray(values, dtype=np.float64)
         if values.shape != desired_shape:
             raise ValueError(
                 "The desired shape of model state '{name}' is {desired_shape}, but provided {obj} '{name}' "

--- a/src/tests/test_SDEModel.py
+++ b/src/tests/test_SDEModel.py
@@ -3,9 +3,9 @@ import pandas as pd
 import numpy as np
 from pySODM.models.base import SDEModel
 
-##################################
+#############################
 ## Model without dimension ##
-##################################
+#############################
 
 class SIR(SDEModel):
 
@@ -80,6 +80,14 @@ def test_SIR_time():
     # Combination of datetime and int/float
     with pytest.raises(ValueError, match="List-like input of simulation start and stop"):
         model.sim([0, pd.to_datetime('2020-03-15')])
+
+    # Wrong type for input argument `tau`
+    with pytest.raises(TypeError, match="discrete timestep 'tau' must be of type int or float"):
+         model.sim(50, tau='hello')
+
+    # Wrong type for input argument `method`
+    with pytest.raises(TypeError, match="solver method 'method' must be of type string"):
+         model.sim(50, method=3)
 
 def test_SIR_date():
     """ Test the use of str/datetime time indexing
@@ -208,9 +216,9 @@ def test_model_init_validation():
     SIR.state_names = ["S", "I", "R"]
     SIR.parameter_names = ['beta', 'gamma']
 
-###################################
+##############################
 ## Model with one dimension ##
-###################################
+##############################
 
 class SIRstratified(SDEModel):
 
@@ -327,9 +335,9 @@ def test_model_stratified_init_validation():
     SIRstratified.parameter_names = ["gamma"]
     SIRstratified.parameter_stratified_names = [["beta"]]
 
-#################################################################
+############################################################
 ## A model with different dimensions for different states ##
-#################################################################
+############################################################
 
 class SIR_SI(SDEModel):
     """


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In some situations, f.i. while prototyping, or if simulating quick-and-dirty, it is advantageous to have a discrete timestepper with a fixed timestep at hand for the ODEModel.

When supplying the argument `tau=1` to `ODEModel.sim()`, the solution is generated by stepping with a fixed length of one.