### PR TITLE
remove warning - not a good idea when simulating in parallel

### DIFF
--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -745,7 +745,7 @@ class ODEModel:
                 raise TypeError(
                     "discrete timestep 'tau' must be of type int or float"
                 )
-            print(f"performing discrete timestepping with tau = {tau}\n")
+            #print(f"performing discrete timestepping with tau = {tau}\n")
 
         # Input checks on supplied simulation time
         time, actual_start_date = validate_simulation_time(time, warmup)


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

I previously printed a warning when the user simulations an ODEModel discretely (`base.py > ODEModel > sim()`),

```python
print(f"performing discrete timestepping with tau = {tau}\n")
```

However, in scenarios where I have to simulate the model dozens of times this is actually more annoying than it is helpful.

So I removed it.
