### PR TITLE
Make bounds obligatory in perturbate theta

### DIFF
--- a/src/pySODM/optimization/mcmc.py
+++ b/src/pySODM/optimization/mcmc.py
@@ -182,21 +182,20 @@ def perturbate_theta(theta, pert, multiplier=2, bounds=None, verbose=None):
     # Validation
     if len(theta) != len(pert):
         raise Exception('The parameter value array "theta" must have the same length as the perturbation value array "pert".')
-    if bounds and (len(bounds) != len(theta)):
+    if len(bounds) != len(theta):
         raise Exception('If bounds is not None, it must contain a tuple for every parameter in theta')
     # Convert theta to np.array
     theta = np.array(theta)
     # Define clipping values: perturbed value must not fall outside this range
-    if bounds:
-        lower_bounds = [bounds[i][0]/(1-pert[i]) for i in range(len(bounds))]
-        upper_bounds = [bounds[i][1]/(1+pert[i]) for i in range(len(bounds))]
+    lower_bounds = [bounds[i][0]/(1-pert[i]) for i in range(len(bounds))]
+    upper_bounds = [bounds[i][1]/(1+pert[i]) for i in range(len(bounds))]
     
     ndim = len(theta)
     nwalkers = ndim*multiplier
     cond_number=np.inf
     retry_counter=0
     while cond_number == np.inf:
-        if bounds and (retry_counter==0):
+        if retry_counter==0:
             theta = np.clip(theta, lower_bounds, upper_bounds)
         pos = theta + theta*pert*np.random.uniform(low=-1,high=1,size=(nwalkers,ndim))
         cond_number = np.linalg.cond(pos)

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -129,7 +129,7 @@ def test_correct_approach_wo_dimension():
         # initialize objective function
         objective_function = log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
         # Perturbate previously obtained estimate
-        ndim, nwalkers, pos = perturbate_theta(theta, pert=0.05*np.ones(len(theta)), multiplier=multiplier_mcmc, bounds=objective_function.expanded_bounds)
+        ndim, nwalkers, pos = perturbate_theta(theta, pert=0.05*np.ones(len(theta)), bounds=objective_function.expanded_bounds, multiplier=multiplier_mcmc)
         # Write some usefull settings to a pickle file (no pd.Timestamps or np.arrays allowed!)
         settings={'start_calibration': 0, 'end_calibration': 50, 'n_chains': nwalkers,
                     'warmup': 0, 'labels': labels, 'parameters': pars, 'starting_estimate': list(theta)}


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

An Msc thesis student ran into the following problem:

He started an MCMC run with a set of perturbated parameters coming from a particle swarm optimisation. To do the perturbation he used the function `pySODM.optimization.mcmc.perturbate_theta()` without the `bounds` arguments. Not using the bounds returned initial estimates for his Markov chains  outside the physical bounds of his system and outside of his uniform priors.

When starting the optimisation like this, first the priors are computed and return infinity. Then, the code corrects the parameter being out-of-bounds to protect the code from returning errors (the bounds provided are regarded as a "never cross" type of boundary). Because the parameter was out of bounds in the first place, the log probability is infinity and `emcee` has no clue on how to update the ensemble. Hence, the chains remain frozen.

Switching the order: first parameter correction, then log prior is unwarranted because, if the parameters are always corrects when outside the bounds, the prior probabilities will never return infinity and thus the emcee can cross the bounds unpunished.

The best fix  here is simply to make `bounds` an obligatory parameter of `perturbate_theta()`. Then, such scenario cannot occur anymore. If a user wants to use the function without bounds, he/she can still provide a tuple with np.inf's in it. 

