### PR TITLE
pass-date-as-timestamp-to-integration-functions

### DIFF
--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -9,7 +9,7 @@ import copy
 import numpy as np
 import numba as nb
 import multiprocessing as mp
-from datetime import timedelta
+from datetime import datetime, timedelta
 from functools import partial
 from scipy.integrate import solve_ivp
 from pySODM.models.utils import int_to_date, list_to_dict
@@ -295,6 +295,7 @@ class SDEModel:
                 if self.time_dependent_parameters:
                     if actual_start_date is not None:
                         date = int_to_date(actual_start_date, t)
+                        t = datetime.timestamp(date)
                     else:
                         date = t
                     for i, (param, param_func) in enumerate(self.time_dependent_parameters.items()):
@@ -597,6 +598,7 @@ class ODEModel:
             if self.time_dependent_parameters:
                 if actual_start_date is not None:
                     date = int_to_date(actual_start_date, t)
+                    t = datetime.timestamp(date)
                 else:
                     date = t
                 for i, (param, param_func) in enumerate(self.time_dependent_parameters.items()):


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

When using dates, the date was not passed to the `integrate()`/`compute_rates()`/`apply_transitions()` functions, which can be disadvantageous to some users. Passing the date as a `datetime.datetime` object prohibits users from using numba's jit compilation so the best way to pass the date is by converting it to the humble `timestamp`, which numba can handle. 

Converting timestamps back to datetime goes as follows,

```python
# current date and time
now = datetime.now()
# convert from datetime to timestamp
ts = datetime.timestamp(now)
```