### PR TITLE
Validate the use of python 3.11

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ When making your own modeling and simulation project, we recommend storing your 
      conda update conda
      ```
 
-- Make an environment file `environment.yml` with the dependencies of your own project.
+- Make an environment file `environment.yml` with the dependencies of your own project. pySODM was validated on Python versions 3.9, 3.10 and 3.11.
 
      ```
      name: MY_ENVIRONMENT
@@ -23,7 +23,7 @@ When making your own modeling and simulation project, we recommend storing your 
      - defaults
      - conda-forge
      dependencies:
-     - python=3.10
+     - python=3.11
      - ...
      - ...
      ```

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.10
+  - python=3.11
   - pandas
   - numpy
   - scipy


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

pySODM works fine under Python 3.11. I have updated the conda environment used for the tutorials. I performed a small and non-scientific speed comparison between Python 3.9 and 3.11 on the workflow tutorial. Python 3.11 seems to outperform Python 3.9 slightly during the MCMC sampling (Python 3.9 - roughly 12 it/s versus Python 3.11 roughly 13 it/s). Hopefully some more speedup in Python 3.12.