### PR TITLE
Omit dependency on numba in base.py

### DIFF
--- a/docs/speedup.md
+++ b/docs/speedup.md
@@ -6,7 +6,7 @@ When using ODE models, using a lower grade algorithm (RK23 < RK45 < DOP853) and/
 
 ### JIT compilation
 
-Just-in-time compilation, made possible by [numba](https://numba.pydata.org/), can be used to speed up code. It is best applied to the `integrate()` function of the `ODEModel` class. The amount of achievable speedup is different for every model. Generally speaking, models with for-loops in them, or models with large matrix computations will speed up quite nicely. Jit compiling the 1D PFR in the [enzyme kinetics](enzyme_kinetics.md) tutorial results in a 16-fold speedup, while jit compiling the PPBB enzyme kinetic model only speeds up the code by 6%. Because the `compute_rates()` function of the `SDEModel` class has a dictionary as its output, it is not possible (yet) to use numba on stochastic models.
+Just-in-time compilation, made possible by [numba](https://numba.pydata.org/), can be used to speed up code. It is best applied to the `integrate()` function of the `ODEModel` class. The amount of achievable speedup is different for every model. Generally speaking, models with for-loops in them, or models with large matrix computations will speed up quite nicely. Jit compiling the 1D PFR in the [enzyme kinetics](enzyme_kinetics.md) tutorial results in a 16-fold speedup, while jit compiling the PPBB enzyme kinetic model only speeds up the code by 6%. Because the `compute_rates()` function of the `SDEModel` class has a dictionary as its output, it is very hard (impossible?) to use numba on stochastic models for now. 
 
 ### Avoid large inputs in time-dependent parameter functions
 

--- a/docs/speedup.md
+++ b/docs/speedup.md
@@ -6,7 +6,7 @@ When using ODE models, using a lower grade algorithm (RK23 < RK45 < DOP853) and/
 
 ### JIT compilation
 
-Just-in-time compilation, made possible by [numba](https://numba.pydata.org/), can be used to speed up code. It is best applied to `integrate()` or time-dependent parameter functions. The amount of achievable speedup is different for every model. Generally speaking, models with for-loops in them, or models with large matrix computations will speed up quite nicely. Jit compiling the 1D PFR in the [enzyme kinetics](enzyme_kinetics.md) tutorial results in a 16-fold speedup, while jit compiling the PPBB enzyme kinetic model only speeds up the code by 6%.
+Just-in-time compilation, made possible by [numba](https://numba.pydata.org/), can be used to speed up code. It is best applied to the `integrate()` function of the `ODEModel` class. The amount of achievable speedup is different for every model. Generally speaking, models with for-loops in them, or models with large matrix computations will speed up quite nicely. Jit compiling the 1D PFR in the [enzyme kinetics](enzyme_kinetics.md) tutorial results in a 16-fold speedup, while jit compiling the PPBB enzyme kinetic model only speeds up the code by 6%. Because the `compute_rates()` function of the `SDEModel` class has a dictionary as its output, it is not possible (yet) to use numba on stochastic models.
 
 ### Avoid large inputs in time-dependent parameter functions
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         'scipy',
         'numpy',
         'pandas',
-        'numba',
         'matplotlib',
         'xarray',
         'emcee',

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -7,7 +7,6 @@ import itertools
 import xarray
 import copy
 import numpy as np
-import numba as nb
 import multiprocessing as mp
 from datetime import datetime, timedelta
 from functools import partial
@@ -220,12 +219,11 @@ class SDEModel:
 
         transitionings={k: v[:] for k, v in rates.items()}
         for k,rate in rates.items():
-            transitionings[k] = self._draw_transitionings(states[k], nb.typed.List(rate), tau)
+            transitionings[k] = self._draw_transitionings(states[k], rate, tau)
 
         return transitionings, tau
 
     @staticmethod
-    @nb.jit(nopython=True)
     def _draw_transitionings(states, rates, tau):
         """
         Draw the transitionings from a multinomial distribution


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

The use of numba on the `_apply_transitionings()` function slowed the SDEModel class simulations down significantly. I validated this on the influenza model where the code ran at 2.8 s/it with the numba compilation and 1.5 s/it without the numba compilation. Omitting numba thus makes the stochastic models nearly twice as fast! Plus, the dependency on numba can be avoided making the code more robust.