### PR TITLE
Improve scaleability of multinomial sampling in `_tau_leap()`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - scipy
   - numba   
   - xarray
+  - matplotlib
   - emcee
   - h5py  
   - tqdm
   - corner
-  - matplotlib

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -230,7 +230,7 @@ class SDEModel:
             Dictionary containing the rates associated with each transitionings of the model states.
 
         tau: int/float
-            Timestep
+            Leap size/simulation timestep
         
         Returns
         -------
@@ -239,14 +239,13 @@ class SDEModel:
             Dictionary containing the number of transitionings for every model state
         
         tau: int/float
-            Timestep
-        
+            Leap size/simulation timestep
         """
 
-        transitionings={k: v[:] for k, v in rates.items()}
+        transitionings = rates.copy()
         for k,rate in rates.items():
             p = 1 - np.exp(-tau*np.stack(rate, axis=-1, dtype=np.float64))
-            s=np.zeros(p.shape[:-1])
+            s=np.zeros(p.shape[:-1], dtype=np.float64)
             for i in range(p.shape[-1]-1):
                 s += p[...,i]
             s = 1 - s

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -8,8 +8,8 @@ import xarray
 import copy
 import numpy as np
 import multiprocessing as mp
-from datetime import datetime, timedelta
 from functools import partial
+from datetime import datetime, timedelta
 from scipy.integrate import solve_ivp
 from pySODM.models.utils import int_to_date, list_to_dict
 from pySODM.models.validation import merge_parameter_names_parameter_stratified_names, validate_draw_function, validate_simulation_time, validate_dimensions, \


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

The random sampling from a multinomial distribution in numpy has one fatal flaw: it isn't vectorized. In the example below, we roll a dice 20 times and want to know  how many times the dice lands on each number if each side of the dice has 1/6 probability. 

```python
np.random.multinomial(20, [1/6.]*6)
array([[4, 1, 7, 5, 2, 1]])
```

In stochastic jump processes the number of repeated experiments is equal to the number of individual in the state. States are np.ndarray`s, f.i. in an SIR model with 10 age groups, every state is a size (10,) np.ndarray. If this state has two possible transitionings, the probabilities can be represented as an (10,2) np.ndarray. Sadly, because np.random.multinomial isn't vectorized, we can't simply supply these np.ndarray's directly to the function but are forced to loop over the length of the states:

```python
@staticmethod
    def _draw_transitionings(states, rates, tau):
        """
        ...
        """

        [...]

        # Step 2: loop + draw
  ---> for i in range(len(states)):
            [...]

        [...]
        return transitioning_out
```

Previously, this issue was fixed by applying the `@numba.njit()` decorator to JIT compile this function. This resulted in satisfactory results for large-scale models (which became very slow without the JIT compilation) but slowed down smaller models by up to half (likely because of the overhead introduced by numba). In this PR, I swapped the np.random.multinomial call for a vectorized equivalent found on stackoverflow. Results are highly satisfactory, smaller models now have runtimes similar to when no JIT is used and larger models have runtimes similar to when JIT was used. Thus, the runtime now scales linearily with the complexity of the model (represented by the total number of states). Further, we can omit the dependency on numba, which makes the code more future-proof. For further details, I refer to the implementation.