### PR TITLE
rename SDEModel JumpProcess and update docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Build
       run: |
         pytest src/tests/test_ODEModel.py
-        pytest src/tests/test_SDEModel.py
+        pytest src/tests/test_JumpProcess.py
         pytest src/tests/test_calibration.py

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ data to compute the posterior probability function, which can subsequently be op
 |                                 | States can be n-dimensional and of different sizes, allowing users to build models with subprocesses                                       |
 |                                 | Allows n-dimensional model states to be labelled with coordinates and dimensions by using `xarray.Dataset}` to store simulation output |
 |                                 | Easy indexing, manipulating, saving, and piping to third-party software of model output by formatting simulation output as `xarray.Dataset` |
-| Simulating the model            | Continuous and discrete deterministic simulation or discrete stochastic simulation (Gillespie's Stochastic Simulation Algorithm or Tau-Leaping) |
+| Simulating the model            | Continuous and discrete deterministic simulation or discrete stochastic simulation (Jump processes, Gillespie's Stochastic Simulation Algorithm or Tau-Leaping) |
 |                                 | Vary model parameters during the simulation generically using a complex function |
 |                                 | Use *draw functions* to perform repeated simulations for sensitivity analysis. With multiprocessing support |
 | Calibrate the model             | Construct and maximize a posterior probability function  |
@@ -62,7 +62,7 @@ The [enzyme kinetics](enzyme_kinetics.md) and [influenza 17-18](influenza_1718.m
     - Version 0.2.3 (2023-05-04, PR #46)
         > Fixed minor bugs encountered when using pySODM for a dynamic input-output model of the Belgian economy. Published to pyPI.
 - Version 0.1 (2022-12-23, PR #14)
-    > Application pySODM to three use cases. Documentation website. Unit tests for ODEModel, SDEModel and calibration. 
+    > Application pySODM to three use cases. Documentation website. Unit tests for ODEModel, JumpProcess and calibration. 
     - Version 0.1.1 (2023-01-09, PR #20)
         > Start of semantic versions: Major.Minor.Patch
     - Version 0.1.2 (2023-01-11, PR #23)

--- a/docs/Markdown reading tool for Notebook.ipynb
+++ b/docs/Markdown reading tool for Notebook.ipynb
@@ -82,7 +82,7 @@
        "\n",
        "#### Stochastic framework\n",
        "\n",
-       "By defining the probabilities of transitioning (propensities) from one state to another, a system of coupled stochastic difference equations (SDEs) can be obtained. The probability to transition from one state to another is assumed to be exponentially distributed. As an example, consider the average time a patient spends in an ICU when recovering, which is $d_{\\text{ICU,R}} = 9.9$ days. The chances of survival in ICU are $(1-m_{\\text{ICU,i}})$, where $m_{\\text{ICU,i}}$ is the mortality in ICU for an individual in age group $i$. The probability of transitioning from state ICU to state $C_{\\text{ICU,rec}}$ on any given day and for an individual in age group $i$ is,\n",
+       "By defining the probabilities of transitioning (propensities) from one state to another, a system of coupled stochastic difference equations (stochastic jump processs) can be obtained. The probability to transition from one state to another is assumed to be exponentially distributed. As an example, consider the average time a patient spends in an ICU when recovering, which is $d_{\\text{ICU,R}} = 9.9$ days. The chances of survival in ICU are $(1-m_{\\text{ICU,i}})$, where $m_{\\text{ICU,i}}$ is the mortality in ICU for an individual in age group $i$. The probability of transitioning from state ICU to state $C_{\\text{ICU,rec}}$ on any given day and for an individual in age group $i$ is,\n",
        "\n",
        "$$\n",
        "\\begin{equation}\n",

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -51,7 +51,7 @@ Always keep in mind additional dependencies lower `pySODM`'s life expectancy. Co
 
 ### Tests
 
-Three test scripts are defined in `~/src/tests/`: 1) `test_ODEModel.py` to test the initializiation and simulation of ODE models, 2) `test_SDEModel.py`, similar but for SDE models and 3) `test_calibration.py`, to test the common calibration workflow. Testing these routines is usefull to verify that modifications made to the `pySODM` code do not break code. Or alternatively, if the code does break, to see where it breaks. The test routines must pass when performing a PR to Github. To run a test locally,
+Three test scripts are defined in `~/src/tests/`: 1) `test_ODEModel.py` to test the initializiation and simulation of ODE models, 2) `test_JumpProcess.py`, similar but for stochastic jump process models and 3) `test_calibration.py`, to test the common calibration workflow. Testing these routines is usefull to verify that modifications made to the `pySODM` code do not break code. Or alternatively, if the code does break, to see where it breaks. The test routines must pass when performing a PR to Github. To run a test locally,
 ```
 conda activate pySODM
 pytest test_calibration.py

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -36,7 +36,7 @@ data to compute the posterior probability function, which can subsequently be op
 |                                 | States can be n-dimensional and of different sizes, allowing users to build models with subprocesses                                       |
 |                                 | Allows n-dimensional model states to be labelled with coordinates and dimensions by using `xarray.Dataset}` to store simulation output |
 |                                 | Easy indexing, manipulating, saving, and piping to third-party software of model output by formatting simulation output as `xarray.Dataset` |
-| Simulating the model            | Continuous and discrete deterministic simulation or discrete stochastic simulation (Gillespie's Stochastic Simulation Algorithm or Tau-Leaping) |
+| Simulating the model            | Continuous and discrete deterministic simulation or discrete stochastic simulation (Jump processes, Gillespie's Stochastic Simulation Algorithm or Tau-Leaping) |
 |                                 | Vary model parameters during the simulation generically using a complex function |
 |                                 | Use *draw functions* to perform repeated simulations for sensitivity analysis. With multiprocessing support |
 | Calibrate the model             | Construct and maximize a posterior probability function  |

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,6 +1,6 @@
 # Models
 
-Standard usage of pySODM involves building an ODE or SDE model. For practical examples of initializing models, we refer to the [tutorials](quickstart.md).
+Standard usage of pySODM involves building an ODE or stochastic jump process model. For practical examples of initializing models, we refer to the [tutorials](quickstart.md).
 
 ## base.py
 
@@ -51,9 +51,9 @@ Upon intialization of the model class, the following arguments must be provided.
 
     * **out** - (xarray.Dataset) - Simulation output. Consult the xarray documentation [here](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.html#xarray.Dataset). `xarray.Dataset.data_vars` are the model states. `xarray.Dataset.dimensions` are the time dimension plus the model's dimensions. The time dimension is named `time` if timesteps were numbers, the time dimension is named `date` if timesteps were dates. When {math}`N > 1` an additional dimension `draws` is added to the output accomodate the repeated simulations.
 
-### *class* SDEModel
+### *class* JumpProcess
 
-The SDEModel class inherits several attributes from the model class defined by the user.
+The JumpProcess class inherits several attributes from the model class defined by the user.
 
 **Inherits from model declaration:**
 

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -8,7 +8,7 @@
 
 **Parameters:**
 
-* **model** (object) - An initialized ODEModel or SDEModel.
+* **model** (object) - An initialized ODEModel or JumpProcess.
 * **parameter_names** (list) - Names of model parameters (type: str) to calibrate. Model parameters must be of type float (0D), list containing float (1D), or np.ndarray (nD).
 * **bounds** (list) - Lower and upper bound of calibrated parameters provided as lists/tuples containing lower and upper bound: example: `[(lb_1, ub_1), ..., (lb_n, ub_n)]`. Values falling outside these bounds will be restricted to the provided ranges before simulating the model.
 * **data** (list) - Contains the datasets (type: pd.Series/pd.DataFrame) the model should be calibrated to. For one dataset use `[dataset,]`. Must contain a time index named `time` or `date`. Additional axes must be implemented using a `pd.Multiindex` and must bear the names/contain the coordinates of a valid model dimension.
@@ -266,7 +266,7 @@ Samples path, identifier and run_date are combined to find the right .hdf5 `emce
 >   Replace every value x in a simulation output with a realization from a Poisson distribution with expectation value x
 
 >    **Parameters:**
->    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `SDEModel`).
+>    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `JumpProcess`).
 
 >    **Returns:**
 >    * **output** (xarray.Dataset) - Simulation output
@@ -276,7 +276,7 @@ Samples path, identifier and run_date are combined to find the right .hdf5 `emce
 >   Replace every value x in a simulation output with a realization from a normal distribution with average x and standard deviation `sigma` (relative=False) or x*`sigma` (relative=True)
 
 >    **Parameters:**
->    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `SDEModel`).
+>    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `JumpProcess`).
 >    * **sigma** (float) - Standard deviation. Must be larger than or equal to 0.
 >    * **relative** (bool) - Add noise relative to magnitude of simulation output.
 
@@ -288,7 +288,7 @@ Samples path, identifier and run_date are combined to find the right .hdf5 `emce
 >   Replace every value x in a simulation output with a realization from a negative binomial distribution with expectation value x and overdispersion `alpha`
 
 >    **Parameters:**
->    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `SDEModel`).
+>    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `JumpProcess`).
 >    * **alpha** (float) - Overdispersion factor. Must be larger than or equal to 0. Reduces to Poisson noise for alpha --> 0.
 
 >    **Returns:**

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -198,16 +198,16 @@ Data variables:
     I_v        (time) float64 2.0 1.798 1.725 ... 1.292e+05 1.365e+05 1.438e+05
 ```
 
-## Set up a dimensionless SDE Model
+## Set up a dimensionless stochastic jump process Model
 
-To stochastically simulate the simple SIR model, the `SDEModel` class is loaded and two functions `compute_rates` and `apply_transitionings` must be defined. For a detailed description of implenting models using Gillespie's methods, we refer to the [manuscript](https://arxiv.org/abs/2301.10664). The rates dictionary defined in `compute_rates` contains the rates of the possible transitionings in the system. These are contained in a list because a state may have multiple possible transitionings. Further, the transitioning for state `I` is a float and this should be a `numpy.float`. I'm still figuring out if I want to introduce the overhead to check and correct this behavior (likely not).
+To stochastically simulate the simple SIR model, the `JumpProcess` class is loaded and two functions `compute_rates` and `apply_transitionings` must be defined. For a detailed mathematical description of implenting models using Gillespie's tau-leaping method (example of a jump proces), we refer to the [manuscript](https://arxiv.org/abs/2301.10664). The rates dictionary defined in `compute_rates` contains the rates of the possible transitionings in the system. These are contained in a list because a state may have multiple possible transitionings. Further, the transitioning for state `I` is a float and this should be a `numpy.float`. I'm still figuring out if I want to introduce the overhead to check and correct this behavior (likely not).
 
 ```python
 # Import the ODEModel class
-from pySODM.models.base import SDEModel
+from pySODM.models.base import JumpProcess
 
 # Define the model equations
-class SIR(SDEModel):
+class SIR(JumpProcess):
 
     states = ['S','I','R']
     parameters = ['beta','gamma']
@@ -238,7 +238,7 @@ class SIR(SDEModel):
 
 ### Draw function
 
-The `sim()` method of `ODEModel` and `SDEModel` can be used to perform {math}`N` repeated simulations (keyword `N`). Additionally a *draw function* can be used to update model parameters during every run. A draw function to randomly draw `gamma` from a uniform simulation before every run is implemented as follows,
+The `sim()` method of `ODEModel` and `JumpProcess` can be used to perform {math}`N` repeated simulations (keyword `N`). Additionally a *draw function* can be used to update model parameters during every run. A draw function to randomly draw `gamma` from a uniform simulation before every run is implemented as follows,
 
 ```python
 def draw_function(param_dict, samples_dict):

--- a/docs/references.md
+++ b/docs/references.md
@@ -6,4 +6,6 @@ In addition to the tutorials listed on the documentation website, we've used pyS
 
 - Alleman T.W., Vergeynst J., De Visscher L., Rollier M., Torfs E., Nopens I., Baetens J.M. (2021). Assessing the effects of non-pharmaceutical interventions on SARS-CoV-2 transmission in Belgium by means of an extended SEIQRD model and public mobility data. *Epidemics*, 37(9). https://doi.org/10.1016/j.epidem.2021.100505
 
-- Alleman T.W., Rollier M., Vergeynst J., Baetens J.M. (2022). A Mobility-Driven Spatially Explicit SEIQRD COVID-19 Model with VOCs, vaccines and seasonality. *arXiv.* https://doi.org/10.48550/ARXIV.2207.03717
+- Alleman T.W., Rollier M., Vergeynst J., Baetens J.M. (2022). A Mobility-Driven Spatially Explicit SEIQRD COVID-19 Model with VOCs, vaccines and seasonality. *Accepted for publication in Applied Mathematical Modeling*. https://doi.org/10.48550/ARXIV.2207.03717
+
+- Alleman T.W., Schoors K., Baetens J.M. (2023). Validating a dynamic input-output model for the propagation of supply and demand shocks during the COVID-19 pandemic in Belgium. *arXiv*. https://arxiv.org/abs/2305.16377

--- a/docs/speedup.md
+++ b/docs/speedup.md
@@ -2,11 +2,11 @@
 
 ### Quick-and-dirty: solver accuracy
 
-When using ODE models, using a lower grade algorithm (RK23 < RK45 < DOP853) and/or a lower relative tolerance of the solver is the easiest way to achieve speedups. Be aware, the default solver settings of `RK23` with a tolerance of `5e-03` is already quite "quick-and-dirty". When using SDE models with the tau-leaping method, try increasing the tau-leap size to speed up your models.
+When using ODE models, using a lower grade algorithm (RK23 < RK45 < DOP853) and/or a lower relative tolerance of the solver is the easiest way to achieve speedups. Be aware, the default solver settings of `RK23` with a tolerance of `5e-03` is already quite "quick-and-dirty". When using stochastic jump process models with the tau-leaping method, try increasing the tau-leap size to speed up your models.
 
 ### JIT compilation
 
-Just-in-time compilation, made possible by [numba](https://numba.pydata.org/), can be used to speed up code. It is best applied to the `integrate()` function of the `ODEModel` class. The amount of achievable speedup is different for every model. Generally speaking, models with for-loops in them, or models with large matrix computations will speed up quite nicely. Jit compiling the 1D PFR in the [enzyme kinetics](enzyme_kinetics.md) tutorial results in a 16-fold speedup, while jit compiling the PPBB enzyme kinetic model only speeds up the code by 6%. Because the `compute_rates()` function of the `SDEModel` class has a dictionary as its output, it is very hard (impossible?) to use numba on stochastic models for now. 
+Just-in-time compilation, made possible by [numba](https://numba.pydata.org/), can be used to speed up code. It is best applied to the `integrate()` function of the `ODEModel` class. The amount of achievable speedup is different for every model. Generally speaking, models with for-loops in them, or models with large matrix computations will speed up quite nicely. Jit compiling the 1D PFR in the [enzyme kinetics](enzyme_kinetics.md) tutorial results in a 16-fold speedup, while jit compiling the PPBB enzyme kinetic model only speeds up the code by 6%. Because the `compute_rates()` function of the `JumpProcess` class has a dictionary as its output, it is very hard (impossible?) to use numba on stochastic models for now. 
 
 ### Avoid large inputs in time-dependent parameter functions
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -458,5 +458,5 @@ I hope this tutorial has demonstrated the workflow pySODM can speedup. However, 
 |------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | Enzyme kinetics: intrinsic kinetics            | Dimensionless ODE model. Calibration to multiple datasets with changing initial conditions.       |
 | Enzyme kinetics: 1D Plug-Flow Reactor          | Use the method of lines to discretise a PDE model into an ODE model with one dimension.           |
-| Influenza 2017-2018                            | SDE model with one dimension. Calibration of a 1D model parameters on a 1D dataset.               |
+| Influenza 2017-2018                            | stochastic jump process model with one dimension. Calibration of a 1D model parameters on a 1D dataset.               |
 | SIR-SI Model (see `~/tutorials/SIR_SI/`)       | ODE model where states have different dimensions and thus different shapes.                       |

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -17,7 +17,7 @@ from pySODM.models.validation import merge_parameter_names_parameter_stratified_
                                             validate_initial_states, validate_integrate_or_compute_rates_signature, validate_provided_parameters, validate_parameter_stratified_sizes, \
                                                 validate_apply_transitionings_signature, validate_compute_rates, validate_apply_transitionings
 
-class SDEModel:
+class JumpProcess:
     """
     Initialise a stochastic differential equations model
 

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -522,7 +522,7 @@ def validate_compute_rates(compute_rates, initial_states, states_shape, paramete
 
     # Throw TDPF parameters out of parameters dictionary
     parameters_wo_TDPF_pars={k:v for k, v in parameters.items() if k in parameter_names_merged}
-    # 'func' in class 'SDEModel' of 'base.py' automatically converts states to np.array
+    # 'func' in class 'JumpProcess' of 'base.py' automatically converts states to np.array
     # However, we do not wish to validate the output of 'func' but rather of its consituent functions: compute_rates, apply_transitionings
     initial_states_copy={k: v[:] for k, v in initial_states.items()}
     for k,v in initial_states.items():

--- a/src/tests/test_JumpProcess.py
+++ b/src/tests/test_JumpProcess.py
@@ -1,13 +1,13 @@
 import pytest
 import pandas as pd
 import numpy as np
-from pySODM.models.base import SDEModel
+from pySODM.models.base import JumpProcess
 
 #############################
 ## Model without dimension ##
 #############################
 
-class SIR(SDEModel):
+class SIR(JumpProcess):
 
     # state variables and parameters
     states = ['S', 'I', 'R']
@@ -220,7 +220,7 @@ def test_model_init_validation():
 ## Model with one dimension ##
 ##############################
 
-class SIRstratified(SDEModel):
+class SIRstratified(JumpProcess):
 
     # state variables and parameters
     states = ['S', 'I', 'R']
@@ -339,7 +339,7 @@ def test_model_stratified_init_validation():
 ## A model with different dimensions for different states ##
 ############################################################
 
-class SIR_SI(SDEModel):
+class SIR_SI(JumpProcess):
     """
     A stochastic, age-stratified SIR model for humans, an unstratified SI model for a disease vector (f.i. mosquito)
     """

--- a/tutorials/SIR_SI/models.py
+++ b/tutorials/SIR_SI/models.py
@@ -1,7 +1,7 @@
 import numpy as np
-from pySODM.models.base import SDEModel, ODEModel
+from pySODM.models.base import JumpProcess, ODEModel
 
-class SDE_SIR_SI(SDEModel):
+class JumpProcess_SIR_SI(JumpProcess):
     """
     A stochastic, age-stratified SIR model for humans, an unstratified SI model for a disease vector (f.i. mosquito)
     """

--- a/tutorials/influenza_1718/calibration.py
+++ b/tutorials/influenza_1718/calibration.py
@@ -74,7 +74,7 @@ initN = pd.Series(index=age_groups, data=np.array([606938, 1328733, 7352492, 220
 ## Load model ##
 ################
 
-from models import SDE_influenza_model as influenza_model
+from models import JumpProcess_influenza_model as influenza_model
 
 #####################################
 ## Define a social policy function ##

--- a/tutorials/influenza_1718/models.py
+++ b/tutorials/influenza_1718/models.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-from pySODM.models.base import ODEModel, SDEModel
+from pySODM.models.base import ODEModel, JumpProcess
 
 class ODE_influenza_model(ODEModel):
     """
@@ -29,7 +29,7 @@ class ODE_influenza_model(ODEModel):
 
         return dS, dE, dIp, dIud, dId, dR, dIm_inc_new
 
-class SDE_influenza_model(SDEModel):
+class JumpProcess_influenza_model(JumpProcess):
     """
     Simple stochastic SEIR model for influenza with undetected carriers
     """

--- a/tutorials/influenza_1718/readme.md
+++ b/tutorials/influenza_1718/readme.md
@@ -1,6 +1,6 @@
 # Contents
 
-The files in this demo illustrate how a simple ODE or SDE model can be setup and calibrated to data.
+The files in this demo illustrate how a simple ODE or stochastic jump process model can be setup and calibrated to data.
 
 # What happens in this tutorial?
 
@@ -9,7 +9,7 @@ First, by running the script `data_conversion.py`, the user converts the *raw* w
 # Files
 
 + `data_conversion.py`: Converts the raw dataset into the interim dataset.
-+ `models.py`: Contains the definition of the SEIR-like ODE and SDE model for Influenza.
++ `models.py`: Contains the definition of the SEIR-like ODE and stochastic jump process model for Influenza.
 + `calibration.py`: Calibrates the SEIR-like ODE model for Influenza to incidence data.
 
 ## Data


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

Technically speaking, Gillespie's tau-leaping method and exact stochastic simulation algorithm are examples of jump processes and not of Stochastic Differential Equations. So the `SDEModel` class was renamed `JumpProcess` as this felt more appropriate.

I think a variable step size tau-leaping algorithm would be a valuable addition to the code.
