### PR TITLE
`ODEModel` class --> `ODE`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,6 @@ jobs:
         pip install -e .[develop]
     - name: Build
       run: |
-        pytest src/tests/test_ODEModel.py
+        pytest src/tests/test_ODE.py
         pytest src/tests/test_JumpProcess.py
         pytest src/tests/test_calibration.py

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The [enzyme kinetics](enzyme_kinetics.md) and [influenza 17-18](influenza_1718.m
     - Version 0.2.3 (2023-05-04, PR #46)
         > Fixed minor bugs encountered when using pySODM for a dynamic input-output model of the Belgian economy. Published to pyPI.
 - Version 0.1 (2022-12-23, PR #14)
-    > Application pySODM to three use cases. Documentation website. Unit tests for ODEModel, JumpProcess and calibration. 
+    > Application pySODM to three use cases. Documentation website. Unit tests for ODE, JumpProcess and calibration. 
     - Version 0.1.1 (2023-01-09, PR #20)
         > Start of semantic versions: Major.Minor.Patch
     - Version 0.1.2 (2023-01-11, PR #23)

--- a/docs/enzyme_kinetics.md
+++ b/docs/enzyme_kinetics.md
@@ -54,9 +54,9 @@ to data from three initial rate experiments, and five full time-course experimen
 We'll start by making a file `models.py` in our working directory, where we'll group our models for this tutorial. Coding up the equations above is very similar to the [simple SIR model](workflow.md).
 
 ```python
-from pySODM.models.base import ODEModel
+from pySODM.models.base import ODE
 
-class PPBB_model(ODEModel):
+class PPBB_model(ODE):
     """
     A model for the enzymatic esterification conversion of D-Glucose and Lauric acid into Glucose Laurate Ester and water
     S + A <--> Es + W
@@ -359,9 +359,9 @@ We'll use the concept of *dimensions* to implement these two-dimensional numpy a
 The derivatives are pre-initialized as zeros and their computation is done by looping over every reacting species and then looping over all spatial nodes except the inlet node ({math}`j=0`). An exception is coded at the outlet, whwere the no-flux boundary approximation is substituted in the system of equations. Stepping through these loops slows the code down and thus we decorate the `integrate()` function with the [numba](https://numba.pydata.org/) `@njit` decorator. Doing so speeds the code up by a factor 16.
 
 ```python
-from pySODM.models.base import ODEModel
+from pySODM.models.base import ODE
 
-class packed_PFR(ODEModel):
+class packed_PFR(ODE):
     """
     A model of a packed-bed plug-flow reactor with axial dispersion in one dimension
     At the surface of the catalyst, the enzymatic esterification conversion of D-Glucose and Lauric acid into Glucose Laurate Ester and water takes place

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -51,7 +51,7 @@ Always keep in mind additional dependencies lower `pySODM`'s life expectancy. Co
 
 ### Tests
 
-Three test scripts are defined in `~/src/tests/`: 1) `test_ODEModel.py` to test the initializiation and simulation of ODE models, 2) `test_JumpProcess.py`, similar but for stochastic jump process models and 3) `test_calibration.py`, to test the common calibration workflow. Testing these routines is usefull to verify that modifications made to the `pySODM` code do not break code. Or alternatively, if the code does break, to see where it breaks. The test routines must pass when performing a PR to Github. To run a test locally,
+Three test scripts are defined in `~/src/tests/`: 1) `test_ODE.py` to test the initializiation and simulation of ODE models, 2) `test_JumpProcess.py`, similar but for stochastic jump process models and 3) `test_calibration.py`, to test the common calibration workflow. Testing these routines is usefull to verify that modifications made to the `pySODM` code do not break code. Or alternatively, if the code does break, to see where it breaks. The test routines must pass when performing a PR to Github. To run a test locally,
 ```
 conda activate pySODM
 pytest test_calibration.py

--- a/docs/models.md
+++ b/docs/models.md
@@ -4,9 +4,9 @@ Standard usage of pySODM involves building an ODE or stochastic jump process mod
 
 ## base.py
 
-###  *class* ODEModel
+###  *class* ODE
 
-The ODEModel class inherits several attributes from the model class defined by the user.
+The ODE class inherits several attributes from the model class defined by the user.
 
 **Inherits from model declaration:**
 

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -8,7 +8,7 @@
 
 **Parameters:**
 
-* **model** (object) - An initialized ODEModel or JumpProcess.
+* **model** (object) - An initialized ODE or JumpProcess.
 * **parameter_names** (list) - Names of model parameters (type: str) to calibrate. Model parameters must be of type float (0D), list containing float (1D), or np.ndarray (nD).
 * **bounds** (list) - Lower and upper bound of calibrated parameters provided as lists/tuples containing lower and upper bound: example: `[(lb_1, ub_1), ..., (lb_n, ub_n)]`. Values falling outside these bounds will be restricted to the provided ranges before simulating the model.
 * **data** (list) - Contains the datasets (type: pd.Series/pd.DataFrame) the model should be calibrated to. For one dataset use `[dataset,]`. Must contain a time index named `time` or `date`. Additional axes must be implemented using a `pd.Multiindex` and must bear the names/contain the coordinates of a valid model dimension.
@@ -266,7 +266,7 @@ Samples path, identifier and run_date are combined to find the right .hdf5 `emce
 >   Replace every value x in a simulation output with a realization from a Poisson distribution with expectation value x
 
 >    **Parameters:**
->    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `JumpProcess`).
+>    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODE` or `JumpProcess`).
 
 >    **Returns:**
 >    * **output** (xarray.Dataset) - Simulation output
@@ -276,7 +276,7 @@ Samples path, identifier and run_date are combined to find the right .hdf5 `emce
 >   Replace every value x in a simulation output with a realization from a normal distribution with average x and standard deviation `sigma` (relative=False) or x*`sigma` (relative=True)
 
 >    **Parameters:**
->    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `JumpProcess`).
+>    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODE` or `JumpProcess`).
 >    * **sigma** (float) - Standard deviation. Must be larger than or equal to 0.
 >    * **relative** (bool) - Add noise relative to magnitude of simulation output.
 
@@ -288,7 +288,7 @@ Samples path, identifier and run_date are combined to find the right .hdf5 `emce
 >   Replace every value x in a simulation output with a realization from a negative binomial distribution with expectation value x and overdispersion `alpha`
 
 >    **Parameters:**
->    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODEModel` or `JumpProcess`).
+>    * **output** (xarray.Dataset) - Simulation output (obtained using the `sim()` function of `ODE` or `JumpProcess`).
 >    * **alpha** (float) - Overdispersion factor. Must be larger than or equal to 0. Reduces to Poisson noise for alpha --> 0.
 
 >    **Returns:**

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Set up a dimensionless ODE model
 
-Load pySODM's [`ODEModel` class](models.md) and define your model. As an example, we'll set up a simple Susceptible-Infectious-Removed (SIR) disease model, schematically represented as follows,
+Load pySODM's [`ODE` class](models.md) and define your model. As an example, we'll set up a simple Susceptible-Infectious-Removed (SIR) disease model, schematically represented as follows,
 
 <img src="./_static/figs/quickstart/quickstart_SIR_flowchart.png" width="500" />
 
@@ -17,11 +17,11 @@ N &=& S + I + R, \\
 ```
 
 ```python
-# Import the ODEModel class
-from pySODM.models.base import ODEModel
+# Import the ODE class
+from pySODM.models.base import ODE
 
 # Define the model equations
-class SIR(ODEModel):
+class SIR(ODE):
 
     states = ['S','I','R']
     parameters = ['beta','gamma']
@@ -88,11 +88,11 @@ The simulation above results in the following trajectories for the number of sus
 To transform all our SIR model's states in 1D vectors, referred to as a *dimension* throughout the documentation, add the `dimensions` keyword to the model declaration. Here, we add a dimension representing the age groups individuals belong to.
 
 ```python
-# Import the ODEModel class
-from pySODM.models.base import ODEModel
+# Import the ODE class
+from pySODM.models.base import ODE
 
 # Define the model equations
-class stratified_SIR(ODEModel):
+class stratified_SIR(ODE):
     
     states = ['S','I','R']
     parameters = ['beta', 'gamma]
@@ -140,7 +140,7 @@ pySODM allows model states to have different coordinates and thus different size
 <img src="./_static/figs/quickstart/quickstart_SIR_SI_flowchart.png" width="700" />
 
 ```python
-class ODE_SIR_SI(ODEModel):
+class ODE_SIR_SI(ODE):
     """
     An age-stratified SIR model for humans, an unstratified SI model for a disease vector (f.i. mosquito)
     """
@@ -203,7 +203,7 @@ Data variables:
 To stochastically simulate the simple SIR model, the `JumpProcess` class is loaded and two functions `compute_rates` and `apply_transitionings` must be defined. For a detailed mathematical description of implenting models using Gillespie's tau-leaping method (example of a jump proces), we refer to the [manuscript](https://arxiv.org/abs/2301.10664). The rates dictionary defined in `compute_rates` contains the rates of the possible transitionings in the system. These are contained in a list because a state may have multiple possible transitionings. Further, the transitioning for state `I` is a float and this should be a `numpy.float`. I'm still figuring out if I want to introduce the overhead to check and correct this behavior (likely not).
 
 ```python
-# Import the ODEModel class
+# Import the ODE class
 from pySODM.models.base import JumpProcess
 
 # Define the model equations
@@ -238,7 +238,7 @@ class SIR(JumpProcess):
 
 ### Draw function
 
-The `sim()` method of `ODEModel` and `JumpProcess` can be used to perform {math}`N` repeated simulations (keyword `N`). Additionally a *draw function* can be used to update model parameters during every run. A draw function to randomly draw `gamma` from a uniform simulation before every run is implemented as follows,
+The `sim()` method of `ODE` and `JumpProcess` can be used to perform {math}`N` repeated simulations (keyword `N`). Additionally a *draw function* can be used to update model parameters during every run. A draw function to randomly draw `gamma` from a uniform simulation before every run is implemented as follows,
 
 ```python
 def draw_function(param_dict, samples_dict):

--- a/docs/speedup.md
+++ b/docs/speedup.md
@@ -6,7 +6,7 @@ When using ODE models, using a lower grade algorithm (RK23 < RK45 < DOP853) and/
 
 ### JIT compilation
 
-Just-in-time compilation, made possible by [numba](https://numba.pydata.org/), can be used to speed up code. It is best applied to the `integrate()` function of the `ODEModel` class. The amount of achievable speedup is different for every model. Generally speaking, models with for-loops in them, or models with large matrix computations will speed up quite nicely. Jit compiling the 1D PFR in the [enzyme kinetics](enzyme_kinetics.md) tutorial results in a 16-fold speedup, while jit compiling the PPBB enzyme kinetic model only speeds up the code by 6%. Because the `compute_rates()` function of the `JumpProcess` class has a dictionary as its output, it is very hard (impossible?) to use numba on stochastic models for now. 
+Just-in-time compilation, made possible by [numba](https://numba.pydata.org/), can be used to speed up code. It is best applied to the `integrate()` function of the `ODE` class. The amount of achievable speedup is different for every model. Generally speaking, models with for-loops in them, or models with large matrix computations will speed up quite nicely. Jit compiling the 1D PFR in the [enzyme kinetics](enzyme_kinetics.md) tutorial results in a 16-fold speedup, while jit compiling the PPBB enzyme kinetic model only speeds up the code by 6%. Because the `compute_rates()` function of the `JumpProcess` class has a dictionary as its output, it is very hard (impossible?) to use numba on stochastic models for now. 
 
 ### Avoid large inputs in time-dependent parameter functions
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -84,23 +84,23 @@ N &=& S + I + R, \\
 \end{eqnarray}
 ```
 
-The model has three states: 1) The number of individuals susceptible to the disease (S), 2) the number of infectious individuals (I), and 3) the number of removed individuals (R). The model has two parameters: 1) `beta`, the rate of transmission and, 2) `gamma`, the duration of infectiousness. Building a model is based on the class inheritance, the user must first load the `ODEModel` class from `~/src/models/base.by`. Then, the user must define his/her own class which must contain (minimally),
+The model has three states: 1) The number of individuals susceptible to the disease (S), 2) the number of infectious individuals (I), and 3) the number of removed individuals (R). The model has two parameters: 1) `beta`, the rate of transmission and, 2) `gamma`, the duration of infectiousness. Building a model is based on the class inheritance, the user must first load the `ODE` class from `~/src/models/base.by`. Then, the user must define his/her own class which must contain (minimally),
 - A list containing the state names `states`,
 - A list containing the parameter names `parameter_names`,
 - An `integrate()` function where the differentials of the model are computed,
 
-and take the `ODEModel` class as its input. Checkout the documentation of the ODEModel class [here](models.md). There are some important formatting requirements to the integrate function, which are verified when the model is initialized,
+and take the `ODE` class as its input. Checkout the documentation of the ODE class [here](models.md). There are some important formatting requirements to the integrate function, which are verified when the model is initialized,
 1. The integrate function must have the timestep `t` as its first input
 2. The model states and parameters must also be given as input, their order does not make a difference
 3. The integrate function must return a differential for every model state, arranged in the same order as the state names defined in `states`
 4. The integrate function must be a static method (include `@staticmethod`)
 
 ```
-# Import the ODEModel class
-from pySODM.models.base import ODEModel
+# Import the ODE class
+from pySODM.models.base import ODE
 
 # Define the model equations
-class ODE_SIR(ODEModel):
+class ODE_SIR(ODE):
     """
     Simple SIR model without dimensions
     """

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -481,7 +481,7 @@ class JumpProcess:
 ## ODE Models ##
 ################
 
-class ODEModel:
+class ODE:
     """
     Initialise an ordinary differential equations model
 

--- a/src/tests/test_ODE.py
+++ b/src/tests/test_ODE.py
@@ -1,13 +1,13 @@
 import pytest
 import pandas as pd
 import numpy as np
-from pySODM.models.base import ODEModel
+from pySODM.models.base import ODE
 
 #############################
 ## Model without dimension ##
 #############################
 
-class SIR(ODEModel):
+class SIR(ODE):
     """A Simple SIR model without dimension
     """
 
@@ -213,7 +213,7 @@ def test_model_init_validation():
 ## Model with one dimension ##
 ###################################
 
-class SIRstratified(ODEModel):
+class SIRstratified(ODE):
     """An SIR Model with one dimension and the same state size
     """
     states = ['S', 'I', 'R']
@@ -329,7 +329,7 @@ def test_stratified_SIR_init_validation():
 ## A model with different dimensions for different states ##
 ############################################################
 
-class SIR_SI(ODEModel):
+class SIR_SI(ODE):
     """
     An age-stratified SIR model for humans, an unstratified SI model for a disease vector (f.i. mosquito) with a twist
     The S states is higher-dimensional to test the possiblities

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -3,13 +3,13 @@ import datetime
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
-from pySODM.models.base import ODEModel
+from pySODM.models.base import ODE
 from pySODM.optimization import pso, nelder_mead
 from pySODM.optimization.utils import add_negative_binomial_noise
 from pySODM.optimization.objective_functions import log_posterior_probability, ll_poisson, ll_negative_binomial
 from pySODM.optimization.mcmc import perturbate_theta, run_EnsembleSampler, emcee_sampler_to_dictionary
 
-# Only tested for ODEModel but the model output is identical so this shouldn't matter
+# Only tested for ODE but the model output is identical so this shouldn't matter
 
 ##############
 ## Settings ##
@@ -43,7 +43,7 @@ for age_group in age_groups:
 ## Model without dimension ##
 #############################
 
-class SIR(ODEModel):
+class SIR(ODE):
 
     # state variables and parameters
     states = ['S', 'I', 'R']
@@ -308,7 +308,7 @@ def test_xarray_datasets():
     objective_function = log_posterior_probability(model,pars,bounds,data,states,
                                                     log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
 
-class SIR_nd_beta(ODEModel):
+class SIR_nd_beta(ODE):
 
     # state variables and parameters
     states = ['S', 'I', 'R']
@@ -356,7 +356,7 @@ def test_calibration_nd_parameter():
 ## Model with one dimension ##
 ###################################
 
-class SIRstratified(ODEModel):
+class SIRstratified(ODE):
 
     # state variables and parameters
     states = ['S', 'I', 'R']
@@ -500,7 +500,7 @@ def break_log_likelihood_functions_with_one_dimension():
 ## Model with two dimensions ##
 ####################################
 
-class SIRdoublestratified(ODEModel):
+class SIRdoublestratified(ODE):
 
     # state variables and parameters
     states = ['S', 'I', 'R']
@@ -675,7 +675,7 @@ def break_log_likelihood_functions_with_two_dimensions():
 ## Model where states have different dimensions ##
 ##################################################
 
-class ODE_SIR_SI(ODEModel):
+class ODE_SIR_SI(ODE):
     """
     An age-stratified SIR model for humans, an unstratified SI model for a disease vector (f.i. mosquito)
     """

--- a/tutorials/SIR/workflow_tutorial.py
+++ b/tutorials/SIR/workflow_tutorial.py
@@ -46,11 +46,11 @@ d = d[d.index.dayofweek < 5]
 ## Define model ##
 ##################
 
-# Import the ODEModel class
-from pySODM.models.base import ODEModel
+# Import the ODE class
+from pySODM.models.base import ODE
 
 # Define the model equations
-class ODE_SIR(ODEModel):
+class ODE_SIR(ODE):
     """
     Simple SIR model without dimensions
     """

--- a/tutorials/SIR_SI/calibration.py
+++ b/tutorials/SIR_SI/calibration.py
@@ -29,7 +29,7 @@ warnings.filterwarnings("ignore")
 ## Define model ##
 ##################
 
-# Import the ODEModel class
+# Import the ODE class
 from models import ODE_SIR_SI as SIR_SI
 # Define parameters and initial condition
 params={'alpha': np.array([0.05, 0.1, 0.2, 0.15]), 'gamma': 5, 'beta': 7}

--- a/tutorials/SIR_SI/models.py
+++ b/tutorials/SIR_SI/models.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pySODM.models.base import JumpProcess, ODEModel
+from pySODM.models.base import JumpProcess, ODE
 
 class JumpProcess_SIR_SI(JumpProcess):
     """
@@ -39,7 +39,7 @@ class JumpProcess_SIR_SI(JumpProcess):
 
         return S_new, I_new, R_new, S_v_new, I_v_new
 
-class ODE_SIR_SI(ODEModel):
+class ODE_SIR_SI(ODE):
     """
     An age-stratified SIR model for humans, an unstratified SI model for a disease vector (f.i. mosquito)
     """

--- a/tutorials/enzyme_kinetics/models.py
+++ b/tutorials/enzyme_kinetics/models.py
@@ -1,8 +1,8 @@
 import numpy as np
 from numba import njit
-from pySODM.models.base import ODEModel
+from pySODM.models.base import ODE
 
-class packed_PFR(ODEModel):
+class packed_PFR(ODE):
     """
     A model of a packed-bed plug-flow reactor with axial dispersion in one dimension
     At the surface of the catalyst, the enzymatic esterification conversion of D-Glucose and Lauric acid into Glucose Laurate Ester and water takes place
@@ -50,7 +50,7 @@ class packed_PFR(ODEModel):
 
         return dC_F, dC_S
 
-class PPBB_model(ODEModel):
+class PPBB_model(ODE):
     """
     A model for the enzymatic esterification conversion of D-Glucose and Lauric acid into Glucose Laurate Ester and water
     S + A <--> Es + W

--- a/tutorials/influenza_1718/models.py
+++ b/tutorials/influenza_1718/models.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import numpy as np
-from pySODM.models.base import ODEModel, JumpProcess
+from pySODM.models.base import ODE, JumpProcess
 
-class ODE_influenza_model(ODEModel):
+class ODE_influenza_model(ODE):
     """
     Simple SEIR model for influenza with undetected carriers
     """


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In analogy to `JumpProcess` class, which is not named `JumpProcessModel` I renamed the `ODEModel` class to the more simple `ODE`.