### PR TITLE
Validate use of Python 3.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.11
+  - python=3.12
   - pandas
   - numpy
   - scipy

--- a/src/tests/test_JumpProcess.py
+++ b/src/tests/test_JumpProcess.py
@@ -47,7 +47,7 @@ def test_SIR_time():
     output = model.sim(time)
     
     # 'time' present in output
-    assert 'time' in list(output.dims.keys())
+    assert 'time' in list(output.sizes.keys())
     # Default (no specification output frequency): 0, 1, 2, 3, ..., 50
     np.testing.assert_allclose(output["time"], np.arange(0, 51))
     # Numerically speaking everything ok?
@@ -89,6 +89,8 @@ def test_SIR_time():
     with pytest.raises(TypeError, match="solver method 'method' must be of type string"):
          model.sim(50, method=3)
 
+test_SIR_time()
+
 def test_SIR_date():
     """ Test the use of str/datetime time indexing
     """
@@ -104,7 +106,7 @@ def test_SIR_date():
     output = model.sim([pd.Timestamp('2020-01-01'), pd.Timestamp('2020-02-20')])
 
     # Validate
-    assert 'date' in list(output.dims.keys())
+    assert 'date' in list(output.sizes.keys())
     S = output["S"].values.squeeze()
     assert S[0] == 1_000_000 - 10
     assert S.shape == (51, )
@@ -141,7 +143,7 @@ def test_SSA():
     output = model.sim([pd.Timestamp('2020-01-01'), pd.Timestamp('2020-02-20')], method='SSA')
 
     # Validate
-    assert 'date' in list(output.dims.keys())
+    assert 'date' in list(output.sizes.keys())
     S = output["S"].values.squeeze()
     assert S[0] == 1000 - 10
     assert S.shape == (51, )
@@ -517,7 +519,7 @@ def test_draw_function():
     output = model.sim(time, draw_function=draw_function, samples={}, N=5)
 
     # assert dimension 'draws' is present in output
-    assert 'draws' in list(output.dims.keys())
+    assert 'draws' in list(output.sizes.keys())
 
     # wrong draw function
     def draw_function(pardict, samples):

--- a/src/tests/test_ODE.py
+++ b/src/tests/test_ODE.py
@@ -45,7 +45,7 @@ def test_SIR_time():
     output = model.sim(time)
     
     # 'time' present in output
-    assert 'time' in list(output.dims.keys())
+    assert 'time' in list(output.sizes.keys())
     # Default (no specification output frequency): 0, 1, 2, 3, ..., 50
     np.testing.assert_allclose(output["time"], np.arange(0, 51))
     # Numerically speaking everything ok?
@@ -93,7 +93,7 @@ def test_SIR_date():
     output = model.sim([pd.Timestamp('2020-01-01'), pd.Timestamp('2020-02-20')])
 
     # Validate
-    assert 'date' in list(output.dims.keys())
+    assert 'date' in list(output.sizes.keys())
     S = output["S"].values.squeeze()
     assert S[0] == 1_000_000 - 10
     assert S.shape == (51, )
@@ -131,7 +131,7 @@ def test_SIR_discrete_stepper():
     # Simulate model
     output = model.sim(50, tau=1)
     # 'time' present in output
-    assert 'time' in list(output.dims.keys())
+    assert 'time' in list(output.sizes.keys())
     # Default (no specification output frequency): 0, 1, 2, 3, ..., 50
     np.testing.assert_allclose(output["time"], np.arange(0, 51))
     # Numerically speaking everything ok?
@@ -500,7 +500,7 @@ def test_draw_function():
     output = model.sim(time, draw_function=draw_function, samples={}, N=5)
 
     # assert dimension 'draws' is present in output
-    assert 'draws' in list(output.dims.keys())
+    assert 'draws' in list(output.sizes.keys())
 
     # wrong draw function
     def draw_function(pardict, samples):


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

Validated the use of Python 3.12. Resolved the following warning in the unit tests:
```bash
FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
```

