### PR TITLE
Address warnings + remove warning suppression

### DIFF
--- a/tutorials/SIR/workflow_tutorial.py
+++ b/tutorials/SIR/workflow_tutorial.py
@@ -20,10 +20,6 @@ from pySODM.optimization.utils import add_negative_binomial_noise, assign_theta,
 from pySODM.optimization.mcmc import perturbate_theta, run_EnsembleSampler, emcee_sampler_to_dictionary
 from pySODM.optimization.objective_functions import log_posterior_probability, ll_negative_binomial
 
-# Suppress warnings
-import warnings
-warnings.filterwarnings("ignore")
-
 ######################################################
 ## Generate a synthetic dataset with overdispersion ##
 ######################################################
@@ -107,7 +103,7 @@ if __name__ == '__main__':
     # Calibated parameters and bounds
     pars = ['beta',]
     labels = ['$\\beta$',]
-    bounds = [(1e-6,1),]
+    bounds = [(0,10),]
     # Setup objective function (no priors --> uniform priors based on bounds)
     objective_function = log_posterior_probability(model, pars, bounds, data, states, log_likelihood_fnc, log_likelihood_fnc_args, labels=labels)
     # Extract start- and enddate

--- a/tutorials/SIR_SI/calibration.py
+++ b/tutorials/SIR_SI/calibration.py
@@ -21,10 +21,6 @@ from pySODM.optimization.utils import add_negative_binomial_noise, assign_theta,
 from pySODM.optimization.mcmc import perturbate_theta, run_EnsembleSampler, emcee_sampler_to_dictionary
 from pySODM.optimization.objective_functions import log_posterior_probability, ll_negative_binomial, ll_poisson
 
-# Suppress warnings
-import warnings
-warnings.filterwarnings("ignore")
-
 ##################
 ## Define model ##
 ##################

--- a/tutorials/influenza_1718/calibration.py
+++ b/tutorials/influenza_1718/calibration.py
@@ -25,9 +25,6 @@ from pySODM.optimization.mcmc import perturbate_theta, run_EnsembleSampler, emce
 from pySODM.optimization.objective_functions import log_posterior_probability, ll_negative_binomial
 # pySODM dependecies
 import corner
-# Suppress warnings
-import warnings
-warnings.filterwarnings("ignore")
 
 ##############
 ## Settings ##

--- a/tutorials/influenza_1718/calibration.py
+++ b/tutorials/influenza_1718/calibration.py
@@ -49,10 +49,10 @@ processes = int(os.getenv('SLURM_CPUS_ON_NODE', mp.cpu_count()/2)) # Automatical
 ###############
 
 # Load case data
-data = pd.read_csv(os.path.join(os.path.dirname(__file__),'data/interim/data_influenza_1718_format.csv'), index_col=[0,1], parse_dates=True)
+data = pd.read_csv(os.path.join(os.path.dirname(__file__),'data/interim/data_influenza_1718_format.csv'), index_col=[0,1], parse_dates=True, date_format='%Y-%m-%d')
 data = data.squeeze()
 # Load case data per 100K
-data_100K = pd.read_csv(os.path.join(os.path.dirname(__file__),'data/interim/data_influenza_1718_format_100K.csv'), index_col=[0,1], parse_dates=True)
+data_100K = pd.read_csv(os.path.join(os.path.dirname(__file__),'data/interim/data_influenza_1718_format_100K.csv'), index_col=[0,1], parse_dates=True, date_format='%Y-%m-%d')
 data_100K = data_100K.squeeze()
 # Re-insert pd.IntervalIndex (pd.IntervalIndex is always loaded as a string..)
 age_groups = pd.IntervalIndex.from_tuples([(0,5),(5,15),(15,65),(65,120)], closed='left')


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In the tutorials, warnings were suppressed using the following code: 

```python
# Suppress warnings
import warnings
warnings.filterwarnings("ignore")
```

However, suppressing warnings is undesirable. So I've gone through all the unit tests and tutorials, removed any warning suppression, and addressed one warning that popped up. In `~/influenza_1718/calibration.py`, 

```python
data = pd.read_csv(os.path.join(os.path.dirname(__file__),'data/interim/data_influenza_1718_format.csv'), index_col=[0,1], parse_dates=True)
```
was changed into,

```python
data = pd.read_csv(os.path.join(os.path.dirname(__file__),'data/interim/data_influenza_1718_format.csv'), index_col=[0,1], parse_dates=True, date_format='%Y-%m-%d')
```

because pandas threw a warning that it had trouble parsing the dates. Only two warnings that don't require further attention remain (listing them here for bookkeeping purposes):

1. In the SIR `workflow_tutorial.py`, when printing the autocorrelation of the MCMC sampler, this yields a divide by zero/overflow warning (see below). I looked in the `emcee` code to study the error, and it is caused by the first autocorrelation being zero. Idk why this is zero tho, played with the perturbation on the initial estimate, etc. Chains don't go out of bounds, really weird but it's only present in this tutorial so I'm leaving it like this. 

```bash
/home/twallema/anaconda3/envs/PYSODM/lib/python3.12/site-packages/emcee/autocorr.py:38: RuntimeWarning: invalid value encountered in divide
  acf /= acf[0]
```

2. In the test_ODE.py unit test, a model is tested with a "square" state of dimensions 'age_groups' x 'age_groups' and this yields the following warning:

```bash
 src/tests/test_ODE.py::test_SIR_SI_state_shapes
  /home/twallema/anaconda3/envs/PYSODM/lib/python3.12/site-packages/xarray/namedarray/core.py:496: UserWarning: Duplicate dimension names present: dimensions {'age_group'} appear more than once in dims=('time', 'age_group', 'age_group'). We do not yet support duplicate dimension names, but we do allow initial construction of the object. We recommend you rename the dims immediately to become distinct, as most xarray functionality is likely to fail silently if you do not. To rename the dimensions you will need to set the ``.dims`` attribute of each variable, ``e.g. var.dims=('x0', 'x1')``.
    warnings.warn(
```
