### PR TITLE
Close issue 62, change names input parameters 'draw_functions' to 'parameters' and 'samples' instead of 'param_dict' and 'samples_dict'

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The [enzyme kinetics](enzyme_kinetics.md) and [influenza 17-18](influenza_1718.m
     - Version 0.2.4 (2023-12-04, PR #62)
         > Validated the use of Python 3.11. Efficiency gains in simulation of jump processes. Ommitted dependency on Numba. All changes related to publishing our software manuscript in Journal of Computational Science. Improved nomenclature in model defenition.
     - IN PROGRESS: 0.2.5
-        > Validated the use of Python 3.12. Validated pySODM on macOS Sonoma 14.5.
+        > Validated the use of Python 3.12. Validated pySODM on macOS Sonoma 14.5. Input arguments of 'draw functions' must now be named 'parameters' and 'samples' instead of 'param_dict' and 'samples_dict'.
 - Version 0.1 (2022-12-23, PR #14)
     > Application pySODM to three use cases. Documentation website. Unit tests for ODE, JumpProcess and calibration. 
     - Version 0.1.1 (2023-01-09, PR #20)

--- a/docs/enzyme_kinetics.md
+++ b/docs/enzyme_kinetics.md
@@ -251,14 +251,14 @@ Finally, we can use the *draw functions* to propagate the parameter samples in o
 ```python
 if __name__ == '__main__':
 
-    def draw_fcn(param_dict, samples_dict):
+    def draw_fcn(parameters, samples):
         # Always draw correlated samples at the SAME INDEX! 
-        idx, param_dict['Vf_Ks'] = random.choice(list(enumerate(samples_dict['Vf_Ks'])))
-        param_dict['R_AS'] = samples_dict['R_AS'][idx]
-        param_dict['R_AW'] = samples_dict['R_AW'][idx]
-        param_dict['R_Es'] = samples_dict['R_Es'][idx]
-        param_dict['K_eq'] = samples_dict['K_eq'][idx]
-        return param_dict
+        idx, parameters['Vf_Ks'] = random.choice(list(enumerate(samples['Vf_Ks'])))
+        parameters['R_AS'] = samples['R_AS'][idx]
+        parameters['R_AW'] = samples['R_AW'][idx]
+        parameters['R_Es'] = samples['R_Es'][idx]
+        parameters['K_eq'] = samples['K_eq'][idx]
+        return parameters
 
     # Loop over datasets
     for i,df in enumerate(data):
@@ -425,16 +425,16 @@ Next, we load our previously obtained samples of the kinetic parameters and defi
 ```python
 # Load samples
 f = open(os.path.join(os.path.dirname(__file__),'data/username_SAMPLES_2023-06-07.json'))
-samples_dict = json.load(f)
+samples = json.load(f)
 
 # Define draw function
-def draw_fcn(param_dict, samples_dict):
-    idx, param_dict['Vf_Ks'] = random.choice(list(enumerate(samples_dict['Vf_Ks'])))
-    param_dict['R_AS'] = samples_dict['R_AS'][idx]
-    param_dict['R_AW'] = samples_dict['R_AW'][idx]
-    param_dict['R_Es'] = samples_dict['R_Es'][idx]
-    param_dict['K_eq'] = samples_dict['K_eq'][idx]
-    return param_dict
+def draw_fcn(parameters, samples):
+    idx, parameters['Vf_Ks'] = random.choice(list(enumerate(samples['Vf_Ks'])))
+    parameters['R_AS'] = samples['R_AS'][idx]
+    parameters['R_AW'] = samples['R_AW'][idx]
+    parameters['R_Es'] = samples['R_Es'][idx]
+    parameters['K_eq'] = samples['K_eq'][idx]
+    return parameters
 ```
 
 A first experiment with the continuous flow reactor was performed using a reaction mixture containing 30 mM D-glucose, 60 mM lauric acid and 28 mM water. The reactants were pumped through the reactor at a flow rate of 0.2 mL/min, resulting in an average residence time of 13.5 minutes. After ten retention times, when the outlet concentration had stabilized, three samples were withdrawn at the outlet. Then, the reactor was cut short by 0.10 m, and again three samples were withdrawn at the outlet. In this way, the reactant profile acrosss the reactor length was obtained. I omit the code to replicate the following figures from this documentation as no new concepts are introduced beyond this point. Our packed-bed model does an adequate job at describing the data.

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -51,11 +51,12 @@ Always keep in mind additional dependencies lower `pySODM`'s life expectancy. Co
 
 ### Tests
 
-Three test scripts are defined in `~/src/tests/`: 1) `test_ODE.py` to test the initializiation and simulation of ODE models, 2) `test_JumpProcess.py`, similar but for stochastic jump process models and 3) `test_calibration.py`, to test the common calibration workflow. Testing these routines is usefull to verify that modifications made to the `pySODM` code do not break code. Or alternatively, if the code does break, to see where it breaks. The test routines must pass when performing a PR to Github. To run a test locally,
+Three unit tests are defined in `~/src/tests/`: 1) `test_ODE.py` to test the initializiation and simulation of ODE models, 2) `test_JumpProcess.py`, to test the initialization and simulation of stochastic jump process models and 3) `test_calibration.py`, to test the calibration workflow. Passing these routines is mandatory to perform a pull request to pySODM's GitHub repository. It verifies that modifications made to the `pySODM` code do not break any of its features. Or alternatively, unit tests can be exploited to see where code breaks. To run the tests locally,
 ```
-conda activate pySODM
+conda activate PYSODM
 pytest test_calibration.py
 ```
+Make sure you have the development dependencies installed to use `pytest` (to do this install pySODM using the command `pip install -e ".[develop]"`)
 
 ### Documentation
 
@@ -63,11 +64,15 @@ pytest test_calibration.py
 
 Documentation consists of both the technical matter about the code as well as background information on the models. To keep these up to date and centralized, we use [Sphinx](https://www.sphinx-doc.org/en/master/) which enables us to keep the documentation together on a website.
 
-The Sphinx setup provides the usage of both `.rst` file, i.e. [restructuredtext](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html) as well as `.md` files, i.e. [Markdown](https://www.markdownguide.org/basic-syntax/). The latter is generally experienced as easier to write, while the former provides more advanced functionalities. Existing pages of the documentation reside in `~/docs/` and can be adjusted directly. In case you want to build the documentation locally, make sure you have the development dependencies installed (`pip install -e ".[develop]"`) to run the sphinx build script. To build locally, use,
-```
+The Sphinx setup provides the usage of both `.rst` file, i.e. [restructuredtext](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html) as well as `.md` files, i.e. [Markdown](https://www.markdownguide.org/basic-syntax/). The latter is generally experienced as easier to write, while the former provides more advanced functionalities. Existing pages of the documentation reside in `~/docs/` and can be adjusted directly. In case you want to build the documentation locally, make sure you have the development dependencies installed (`pip install -e ".[develop]"`) to run the sphinx build script. To build locally, run the following command in the home directory,
+```bash
 python setup.py build_sphinx
 ```
-When you want to create a new page, make sure to add the page to the `index.rst` in order to make the page part of the website. The website is build automatically using [github actions](https://github.com/twallema/pySODM/blob/master/.github/workflows/deploy.yml#L22-L24) and the output is deployed to [https://twallema.github.io/pySODM/](https://twallema.github.io/pySODM/). The resulting html-website is created in the directory `build/html`. Double click any of the `html` file in the folder to open the website in your browser (no server required).
+which compiles the html-website in the directory `build/html`. Double click any of the `html` file in the folder to open the website in your browser (no server required). Or alternatively, run the following command in the 'docs' directory,
+```bash
+make html
+```
+which compiles the website in the directory `docs/_build`. When you want to create a new page, make sure to add the page to the `index.rst` in order to make the page part of the website. The website is build automatically using [github actions](https://github.com/twallema/pySODM/blob/master/.github/workflows/deploy.yml#L22-L24) and the output is deployed to [https://twallema.github.io/pySODM/](https://twallema.github.io/pySODM/).
 
 #### Docstrings
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -32,14 +32,14 @@ Upon intialization of the model class, the following arguments must be provided.
 
 * **sim(time, N=1, draw_function=None, samples=None, processes=None, method='RK23', rtol=1e-3, tau=None, output_timestep=1, warmup=0)**
 
-    Simulate a model over a given time period using `scipy.integrate.solve_ivp()`. Can optionally perform `N` repeated simulations. Can change the values of model parameters at every repeated simulation by drawing samples from a dictionary `samples` using a function `draw_function`.
+    Simulate a model over a given time period using `scipy.integrate.solve_ivp()`. Can optionally perform `N` repeated simulations. Can change the values of model parameters at every repeated simulation by drawing parameter samples from a dictionary `samples` using a function `draw_function`.
 
     **Parameters**
 
     * **time** - (int/float or list) - The start and stop "time" for the simulation run. Three possible inputs: 1) int/float, 2) list of int/float of type `[start_time, stop_time]`, 3) list of pd.Timestamp or str of type `[start_date, stop_date]`.
     * **N** - (int) - optional - Number of repeated simulations to perform.
-    * **samples** - (dict) - optional - Dictionary containing samples of model parameters. Obligatory input to a *draw function*.   
-    * **draw_function** - (function) - optional - A function consisting of two inputs: the model parameters dictionary `param_dict`, the previously documented samples dictionary `samples_dict`. Function must return the model parameters dictionary `param_dict`. Function can be used to update a model parameter's value during every repeated simulation. Usefull to propagate MCMC samples of model parameters or perform sensitivity analyses.
+    * **samples** - (dict) - optional - Dictionary containing samples of the distribution of model parameters. Obligatory input to a *draw function*. Advanced users: dictionary can contain any arbitrary input to a *draw function*.
+    * **draw_function** - (function) - optional - A function consisting of two inputs: the model parameters dictionary `parameters`, the previously documented samples dictionary `samples`. Function must return the model parameters dictionary `parameters` with its keys unaltered. Function can be used to update a model parameter's value during every repeated simulation. Usefull to propagate MCMC samples of model parameters or perform sensitivity analyses.
     * **processes** - (int) - optional - Number of cores to use when {math}`N > 1`.
     * **method** - (str) - optional - Integration methods of `scipy.integrate.solve_ivp()` (read the [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html)).
     * **rtol** - (int/float) - optional - Relative tolerance of `scipy.integrate.solve_ivp()` (read the [docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html)).
@@ -86,8 +86,8 @@ Upon intialization of the model class, the following arguments must be provided.
 
     * **time** - (int/float or list) - The start and stop "time" for the simulation run. Three possible inputs: 1) int/float, 2) list of int/float of type `[start_time, stop_time]`, 3) list of pd.Timestamp or str of type `[start_date, stop_date]`.
     * **N** - (int) - optional - Number of repeated simulations to perform.
-    * **samples** - (dict) - optional - Dictionary containing samples of model parameters. Obligatory input to a *draw function*.   
-    * **draw_function** - (function) - optional - A function consisting of two inputs: the model parameters dictionary `param_dict`, the previously documented samples dictionary `samples_dict`. Function must return the model parameters dictionary `param_dict`. Function can be used to update a model parameter's value during every repeated simulation. Usefull to propagate MCMC samples of model parameters or perform sensitivity analyses.
+    * **samples** - (dict) - optional - Dictionary containing samples of the distribution of model parameters. Obligatory input to a *draw function*. Advanced users: dictionary can contain any arbitrary input to a *draw function*.
+    * **draw_function** - (function) - optional - A function consisting of two inputs: the model parameters dictionary `parameters`, the previously documented samples dictionary `samples`. Function must return the model parameters dictionary `parameters`. Function can be used to update a model parameter's value during every repeated simulation. Usefull to propagate MCMC samples of model parameters or perform sensitivity analyses.
     * **processes** - (int) - optional - Number of cores to use when {math}`N > 1`.
     * **method** - (str) - optional - 'SSA': Stochastic Simulation Algorithm. 'tau-leap': Tau-leaping algorithm. Consult the following [blog](https://lewiscoleblog.com/gillespie-algorithm) for more background information.
     * **tau** - (int/float) - optional - Leap value of the tau-leaping method. Consult the following [blog](https://lewiscoleblog.com/gillespie-algorithm) for more background information.

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -257,7 +257,7 @@
 Samples path, identifier and run_date are combined to find the right .hdf5 `emcee` backend and the `.json` containing the settings. 
 
 >   **Returns:**
->   * **samples_dict** (dict) - Dictionary containing the discarded and thinned MCMC samples and settings.
+>   * **samples** (dict) - Dictionary containing the discarded and thinned MCMC samples and settings.
  
 ## utils.py
 

--- a/docs/start_to_collaborate.md
+++ b/docs/start_to_collaborate.md
@@ -6,7 +6,7 @@ First of all, thanks for considering contributing to pySODM! It's people like yo
 
 Using pySODM for a research project and writing a paper? Consider citing it:
 
-Tijs W. Alleman, Christian Stevens and Jan. M. Baetens. (2023). pySODM: Simulating and Optimising Dynamical Models in Python 3. arXiv preprint. DOI: https://doi.org/10.48550/arXiv.2301.10664
+Tijs W. Alleman, Christian Stevens and Jan. M. Baetens. (2023). pySODM: Simulating and Optimising Dynamical Models in Python 3. Journal of Computational Science. DOI: https://doi.org/10.1016/j.jocs.2023.102148 
 
 ### Ask a question
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -16,7 +16,7 @@ By using a simple model, we can focus on the general workflow and on the most im
 
 I typically place all my dependencies together at the top of my script. However, for this demo, we'll import some common dependencies here and then import the pySODM code on the go. That way, the imports of the necessary pySODM code are located where they are required which is more illustrative than including them all here at once.
 
-```
+```python
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -32,7 +32,7 @@ n_{cases}(t) = \exp \Big( t *  \dfrac{\log 2}{t_d} \Big)
 
 We'll assume the first case was detected on December 1st, 2022 and data was collected on every weekday until December 21st, 2022. Then, we'll add observational noise to the synthetic data. For count based data, observational noise is typically the result of a poisson or negative binomial proces, depending on the occurence of overdispersion. For a poisson proces, the variance in the data is equal to the mean: {math}`\sigma^2 = \mu`, while for a negative binomial proces the mean-variance relationship is quadratic: {math}`\sigma^2 = \mu + \alpha \mu^2`. For this example we'll use the negative binomial distribution with a dispersion factor of `alpha=0.03`, which was representative for the data used during the COVID-19 pandemic in Belgium. Note that for {math}`\alpha=0`, the variance of the negative binomial distribution is equal to the variance of the poisson distribution.
 
-```
+```python
 # Parameters 
 alpha = 0.03    # Overdispersion
 t_d = 10         # Exponential doubling time
@@ -50,7 +50,7 @@ d = d[d.index.dayofweek < 5]
 
 Datasets used in an optimization must always be a `pd.Series`, in case the model has no dimensions, or a `pd.DataFrame` with a `pd.MultiIndex` if the model has dimensions. In the dataset, an index level named `time` (if the time axis consists of int/float) or `date` (if the time axis consists of dates) must always be present. In this tutorial, we'll use dates and thus we rename the index of our dataset `date`. 
 
-```
+```python
 # Index name must be data for calibration to work
 d.index.name = 'date'
 print(d)
@@ -97,7 +97,7 @@ and take the `ODE` class as its input. Checkout the documentation of the ODE cla
 3. The integrate function must return a differential for every model state, arranged in the same order as the state names defined in `states`
 4. The integrate function must be a static method (include `@staticmethod`)
 
-```
+```python
 # Import the ODE class
 from pySODM.models.base import ODE
 
@@ -125,7 +125,7 @@ class ODE_SIR(ODE):
 
 After defining our model, we'll initialize it by supplying a dictionary of initial states and a dictionary of model parameters. In our example, we'll assume the disease spreads in a relatively small population of 1000 individuals. At the start of the simulation we'll assume there is one "patient zero". We don't have to define the number of recovered individuals as undefined states are automatically set to zero by pySODM.
 
-```
+```python
 model = ODE_SIR(states={'S': 1000, 'I': 1}, parameters={'beta': 0.35, 'gamma': 5})
 ```
 
@@ -206,7 +206,7 @@ Let's initialize an appropriate [posterior probability function](optimization.md
 
 The lengths of the number of `data`, `states`, `log_likelihood function` and `log_likelihood_function_args` must always be equal. In the example, as no prior functions are provided, the priors will default to uniform priors over the provided bounds. Providing a label is also optional, if no label is provided, the names provided in `pars` are used as labels.
 
-```
+```python
 if __name__ == '__main__':
     
     # Import the log_posterior_probability class
@@ -237,7 +237,7 @@ if __name__ == '__main__':
 
 The following code snippet starts a Nelder-Mead optimization from the initial guess {math}`\beta = 0.35`, perturbated with a `step` of 10%. Running on `processes=1` cores for `max_iter=10` iterations.
 
-```
+```python
 if __name__ == '__main__':
     # Import the Nelder-Mead algorithm
     from pySODM.optimization import nelder_mead
@@ -248,7 +248,7 @@ if __name__ == '__main__':
 ```
 We find an optimal value of {math}`\beta \pm 0.27`. We can then asses the goodness-of-fit by updating the dictionary of model parameters with the newly found value for `beta`, simulating the model and visualizing the model prediction and dataset.
 
-```
+```python
 if __name__ == '__main__':
     # Update beta with the calibrated value
     model.parameters.update({'beta': theta[0]})
@@ -275,7 +275,7 @@ We'll use our previous estimate to initiate our Markov-Chain Monte-Carlo sampler
 
 Then, we'll setup and run the sampler using `run_EnsembleSampler()` until the chains converge. We'll run the sampler for `n_mcmc=100` iterations and print the diagnostic autocorrelation and trace plots every `print_n=10` iterations in a folder called `sampler_output/`. For convenience, a copy of the samples is saved there as well. As an identifier for our *experiment*, we'll use `'username'`. While the sampler is running, have a look in the `sampler_output/` folder, which should look as follows,
 
-```
+```bash
 ├── sampler_output 
 |   |── username_BACKEND_2022-12-16.hdf5
 │   ├── autocorrelation
@@ -284,9 +284,9 @@ Then, we'll setup and run the sampler using `run_EnsembleSampler()` until the ch
 │       └── username_TRACE_2022-12-16.pdf
 ```
 
-The output of the above procedure yields an `emcee.EnsembleSampler` object containing our 100 iterations for 9 chains. We can extract the chains quite by using the `get_chain()` method (see the [emcee documentation](https://emcee.readthedocs.io/en/stable/user/sampler/)). However, we're interested in building a dictionary of samples because this interfaces nicely to pySODM's *draw functions* (introduced below). Using `emcee_sampler_to_dictionary()`, the generated chains and the entries provided in `settings` are formatted into a dictionary `samples_dict`, which is automatically saved in a json format. Finally, we'll use the third-party `corner` package to visualize the distributions of the five calibrated parameters.
+The output of the above procedure yields an `emcee.EnsembleSampler` object containing our 100 iterations for 9 chains. We can extract the chains quite by using the `get_chain()` method (see the [emcee documentation](https://emcee.readthedocs.io/en/stable/user/sampler/)). However, we're interested in building a dictionary of samples because this interfaces nicely to pySODM's *draw functions* (introduced below). Using `emcee_sampler_to_dictionary()`, the generated chains and the entries provided in `settings` are formatted into a dictionary `samples`, which is automatically saved in a json format. Finally, we'll use the third-party `corner` package to visualize the distributions of the five calibrated parameters.
 
-```
+```python
 if __name__ == '__main__':
 
     from pySODM.optimization.mcmc import perturbate_theta, run_EnsembleSampler, emcee_sampler_to_dictionary
@@ -329,7 +329,8 @@ For our simple SIR model, the basic reproduction number is defined as,
 R_0 = \frac{\beta}{(1/\gamma)}.
 ```
 Using the obtained samples, we find a basic reproduction number of {math}`R_0 = 1.37 \pm 0.01`. Its distribution looks as follows,
-```
+
+```python
 # Visualize the distribution of the basic reproduction number
 fig,ax=plt.subplots()
 ax.hist(np.array(samples_dict['beta'])*model.parameters['gamma'], density=True, color='black', alpha=0.6)
@@ -344,12 +345,13 @@ plt.close()
 
 Next, let's visualize how well our simple SIR model fits the data. To this end, we'll simulate the model a number of times, and at each time we'll update the value of `beta` with a sample drawn by the MCMC. Then, assuming our model is an adequate representation of the modeled proces, we'll add observational noise to each model trajectory using `add_negative_binomial()`. Finally, we'll visualize the individual model trajectories and the data to asses the goodness-of-fit.
 
-To repeatedly simulate a model and update a parameter value in each consecutive run, we'll use what is called a *draw function*. This function always takes two input arguments, the model parameters dictionary `param_dict` and a dictionary containing samples `samples_dict`, and must always return the model parameters dictionary `param_dict`. The draw function defines how the samples dictionary can be used to update the model parameters dictionary. In our case, we'll use `np.random.choice()` to sample a random value of `beta` from the dictionary of samples and assign it to the model parameteres dictionary, as follows,
-```
+To repeatedly simulate a model and update a parameter value in each consecutive run, we'll use what is called a *draw function*. This function always takes two input arguments, the model parameters dictionary `parameters` and a dictionary containing samples `samples`, and must always return the model parameters dictionary `parameters` (unaltered dictionary keys). The draw function defines how the samples dictionary can be used to update the model parameters dictionary. In our case, we'll use `np.random.choice()` to sample a random value of `beta` from the dictionary of samples and assign it to the model parameteres dictionary, as follows,
+
+```python
 # Define draw function
-def draw_fcn(param_dict, samples_dict):
-    param_dict['beta'] = np.random.choice(np.array(samples_dict['beta']))
-    return param_dict
+def draw_fcn(parameters, samples):
+    parameters['beta'] = np.random.choice(np.array(samples['beta']))
+    return parameters
 ```
 
 Then, we'll provide four additional arguments to `sim()`,
@@ -360,7 +362,7 @@ Then, we'll provide four additional arguments to `sim()`,
 
 As demonstrated in the quickstart example, the `xarray` containing the model output will now contain an additional dimension to accomodate the repeated simulations: `draws`.
 
-```
+```python
 # Simulate model
 out = model.sim([d.index.min(), d.index.max()+pd.Timedelta(days=28)], N=50, samples=samples_dict, draw_fcn=draw_fcn, processes=processes)
 # Add negative binomial observation noise
@@ -386,7 +388,7 @@ Finally, let us introduce the concept of varying model parameters over the cours
 
 We'll first need to implement a function to let our model know how a given parameter should vary over time: a *time-dependent model parameter function* (TDPF). Then, we'll need to re-initialize our model and tell it what model parameter should be varied in accordance to our function. For our problem, a TDPF would have the following syntax,
 
-```
+```python
 # Define a time-dependent parameter function
 def lower_infectivity(t, states, param, start_measures):
     if t < start_measures:
@@ -398,7 +400,7 @@ def lower_infectivity(t, states, param, start_measures):
 This simple function reduces the parameter `param` with a factor two if the simulation date is larger than `start_measures`. A time-dependent model parameter function must always have the arguments `t` (simulation timestep), `states` (dictionary of model states) and `param` (value of the parameter the function is applied to) as inputs. In addition, the user can supply additional arguments to the function, which need to be added to the dictionary of model parameters.
 
 We will apply this function to the infectivity parameter `beta` by using the `time_dependent_parameters` argument of `sim()`.
-```
+```python
 # Attach the additional arguments of the time-depenent function to the parameter dictionary
 model.parameters.update({'start_measures': '2023-01-21'})
 
@@ -409,7 +411,7 @@ model_with = ODE_SIR(states=init_states, parameters=model.parameters,
 
 Next, we compare the simulations with and without the use of our time-dependent model parameter function.
 
-```
+```python
 # Simulate the model
 out_with = model_with.sim([d.index.min(), d.index.max()+pd.Timedelta(days=2*28)], N=50, samples=samples_dict, draw_fcn=draw_fcn, processes=processes)
 
@@ -440,12 +442,12 @@ However, it is unlikely that people would adopt these preventive measures instan
 
 To simulate ramp-like adoptation of measures, we can add the number of additional days it takes beyond January 21st, 2023 to adopt the measures by sampling from a triangular distribution with a minimum and mode of zero days, and a maximum adoptation time of 21 days. All we have to do is add one line to the draw function,
 
-```
+```python
 # Define draw function
-def draw_fcn(param_dict, samples_dict):
-    param_dict['beta'] = np.random.choice(samples_dict['beta'])
-    param_dict['start_measures'] += pd.Timedelta(days=np.random.triangular(left=0,mode=0,right=21))
-    return param_dict
+def draw_fcn(parameters, samples):
+    parameters['beta'] = np.random.choice(samples['beta'])
+    parameters['start_measures'] += pd.Timedelta(days=np.random.triangular(left=0,mode=0,right=21))
+    return parameters
 ```
 
 Gradually adopting the preventive measures results in a more realistic simulation,

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     extras_require={
         "develop":  ["pytest",
                      "sphinx",
+                     "setuptools",
                      "numpydoc",
                      "sphinx_rtd_theme",
                      "myst_parser[sphinx]"],

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -400,7 +400,7 @@ class JumpProcess:
             Number of repeated simulations (default: 1)
 
         draw_function : function
-            A function with as obligatory inputs the dictionary of model parameters and a dictionary of samples
+            A function with as obligatory inputs the dictionary of model parameters 'parameters' and a dictionary of parameter samples 'samples' (can actually contain whatever you'd like as long as its a dict)
             The function can alter parameters in the model parameters dictionary between repeated simulations `N`.
             Usefull to propagate uncertainty, perform sensitivity analysis.
 

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -61,7 +61,7 @@ def validate_simulation_time(time, warmup):
     return time, actual_start_date
 
 def validate_draw_function(draw_function, parameters, samples):
-    """Validates the draw functions input and output. For use in the sim() functions of the ODE and JumpProcess classes (base.py).
+    """Validates the draw function's input and output. For use in the sim() functions of the ODE and JumpProcess classes (base.py).
     
     input
     -----

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -100,7 +100,7 @@ def validate_draw_function(draw_function, parameters, samples):
         )
     if set(d.keys()) != set(parameters.keys()):
         raise ValueError(
-            f"Keys in output dictionary of draw function '{draw_function}' must match the keys in input dictionary 'parameters'.\n"
+            f"Keys in output dictionary of draw function '{draw_function.__name__}' must match the keys in input dictionary 'parameters'.\n"
             "Missing keys in output dict: {0}. Redundant keys in output dict: {1}".format(set(parameters.keys()).difference(set(d.keys())), set(d.keys()).difference(set(parameters.keys())))
         )
 

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -85,8 +85,13 @@ def validate_draw_function(draw_function, parameters, samples):
 
     sig = inspect.signature(draw_function)
     keywords = list(sig.parameters.keys())
-    # Verify that names of draw function are param_dict, samples_dict
-    if ((len(keywords) != 2) | (keywords[0] != "parameters") | (keywords[1] != "samples")):
+    # Verify that names of draw function input args are 'parameters' and 'samples
+    if len(keywords) != 2:
+        raise ValueError(
+            f"Your draw function '{draw_function.__name__}' must have 'parameters' and 'samples' as the names of its inputs. Its current inputs are named: {keywords}"
+        )
+    else:
+        if (keywords[0] != "parameters") | (keywords[1] != "samples"):
             raise ValueError(
             f"Your draw function '{draw_function.__name__}' must have 'parameters' and 'samples' as the names of its inputs. Its current inputs are named: {keywords}"
         )

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -158,8 +158,8 @@ def log_prior_custom(x, args):
 
     Example use:
     ------------
-    # Posterior of 'my_par' in samples_dict['my_par']
-    density_my_par, bins_my_par = np.histogram(samples_dict['my_par'], bins=20, density=True)
+    # Posterior of 'my_par' in samples['my_par']
+    density_my_par, bins_my_par = np.histogram(samples['my_par'], bins=20, density=True)
     density_my_par_norm = density_my_par/np.sum(density_my_par)
     prior_fcn = prior_custom
     prior_fcn_args = (density_my_par_norm, bins_my_par, weight)

--- a/src/tests/test_JumpProcess.py
+++ b/src/tests/test_JumpProcess.py
@@ -509,26 +509,49 @@ def test_draw_function():
     initial_states = {"S": [600_000 - 20, 400_000 - 10], "I": [20, 10]}
     coordinates = {'age_groups': ['0-20','20-120']}
 
-    # draw function
-    def draw_function(param_dict, samples_dict):
-        return param_dict
-
+    # correct draw function
+    def draw_function(parameters, samples):
+        return parameters
     # simulate model
     time = [0, 10]
     model = SIRstratified(initial_states, parameters, coordinates=coordinates)
     output = model.sim(time, draw_function=draw_function, samples={}, N=5)
-
     # assert dimension 'draws' is present in output
     assert 'draws' in list(output.sizes.keys())
 
-    # wrong draw function
-    def draw_function(pardict, samples):
-        return pardict
-    
+    # wrong draw function: not enough input arguments
+    def draw_function(parameters):
+        return parameters
     # simulate model
     time = [0, 10]
     model = SIRstratified(initial_states, parameters, coordinates=coordinates)
-    with pytest.raises(ValueError, match="The first parameter of a draw function should be"):
+    with pytest.raises(ValueError, match="Your draw function 'draw_function' must have 'parameters' and 'samples' as the names of its inputs."):
         model.sim(time, draw_function=draw_function, samples={}, N=5)
 
+    # wrong draw function: input arguments switched
+    def draw_function(samples, parameters):
+        return parameters
+    # simulate model
+    time = [0, 10]
+    model = SIRstratified(initial_states, parameters, coordinates=coordinates)
+    with pytest.raises(ValueError, match="Your draw function 'draw_function' must have 'parameters' and 'samples' as the names of its inputs."):
+        model.sim(time, draw_function=draw_function, samples={}, N=5)
     
+    # wrong draw function: too many input arguments
+    def draw_function(parameters, samples, blublabliblu):
+        return parameters
+    # simulate model
+    time = [0, 10]
+    model = SIRstratified(initial_states, parameters, coordinates=coordinates)
+    with pytest.raises(ValueError, match="Your draw function 'draw_function' must have 'parameters' and 'samples' as the names of its inputs."):
+        model.sim(time, draw_function=draw_function, samples={}, N=5)
+
+    # wrong draw function: put a new keys in model parameters dictionary that doesn't represent a model parameter
+    def draw_function(parameters, samples):
+        parameters['bliblublo'] = 5
+        return parameters
+    # simulate model
+    time = [0, 10]
+    model = SIRstratified(initial_states, parameters, coordinates=coordinates)
+    with pytest.raises(ValueError, match="Keys in output dictionary of draw function 'draw_function' must match the keys in input dictionary 'parameters'."):
+        model.sim(time, draw_function=draw_function, samples={}, N=5)

--- a/src/tests/test_ODE.py
+++ b/src/tests/test_ODE.py
@@ -490,26 +490,49 @@ def test_draw_function():
     initial_states = {"S": [600_000 - 20, 400_000 - 10], "I": [20, 10]}
     coordinates = {'age_groups': ['0-20','20-120']}
 
-    # draw function
-    def draw_function(param_dict, samples_dict):
-        return param_dict
-
+    # correct draw function
+    def draw_function(parameters, samples):
+        return parameters
     # simulate model
     time = [0, 10]
     model = SIRstratified(initial_states, parameters, coordinates=coordinates)
     output = model.sim(time, draw_function=draw_function, samples={}, N=5)
-
     # assert dimension 'draws' is present in output
     assert 'draws' in list(output.sizes.keys())
 
-    # wrong draw function
-    def draw_function(pardict, samples):
-        return pardict
-    
+    # wrong draw function: not enough input arguments
+    def draw_function(parameters):
+        return parameters
     # simulate model
     time = [0, 10]
     model = SIRstratified(initial_states, parameters, coordinates=coordinates)
-    with pytest.raises(ValueError, match="The first parameter of a draw function should be"):
+    with pytest.raises(ValueError, match="Your draw function 'draw_function' must have 'parameters' and 'samples' as the names of its inputs."):
         model.sim(time, draw_function=draw_function, samples={}, N=5)
 
+    # wrong draw function: input arguments switched
+    def draw_function(samples, parameters):
+        return parameters
+    # simulate model
+    time = [0, 10]
+    model = SIRstratified(initial_states, parameters, coordinates=coordinates)
+    with pytest.raises(ValueError, match="Your draw function 'draw_function' must have 'parameters' and 'samples' as the names of its inputs."):
+        model.sim(time, draw_function=draw_function, samples={}, N=5)
     
+    # wrong draw function: too many input arguments
+    def draw_function(parameters, samples, blublabliblu):
+        return parameters
+    # simulate model
+    time = [0, 10]
+    model = SIRstratified(initial_states, parameters, coordinates=coordinates)
+    with pytest.raises(ValueError, match="Your draw function 'draw_function' must have 'parameters' and 'samples' as the names of its inputs."):
+        model.sim(time, draw_function=draw_function, samples={}, N=5)
+
+    # wrong draw function: put a new keys in model parameters dictionary that doesn't represent a model parameter
+    def draw_function(parameters, samples):
+        parameters['bliblublo'] = 5
+        return parameters
+    # simulate model
+    time = [0, 10]
+    model = SIRstratified(initial_states, parameters, coordinates=coordinates)
+    with pytest.raises(ValueError, match="Keys in output dictionary of draw function 'draw_function' must match the keys in input dictionary 'parameters'."):
+        model.sim(time, draw_function=draw_function, samples={}, N=5)

--- a/tutorials/SIR/workflow_tutorial.py
+++ b/tutorials/SIR/workflow_tutorial.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
 
     # Define draw function
     def draw_fcn(parameters, samples):
-        parameters['beta'] = np.random.choice(samples_dict['beta'])
+        parameters['beta'] = np.random.choice(samples['beta'])
         return parameters
     # Simulate model
     out = model.sim([start_date, end_date+pd.Timedelta(days=2*28)], N=100, samples=samples_dict, draw_function=draw_fcn, processes=processes)
@@ -206,7 +206,7 @@ if __name__ == '__main__':
 
     # Define draw function
     def draw_fcn(parameters, samples):
-        parameters['beta'] = np.random.choice(samples_dict['beta'])
+        parameters['beta'] = np.random.choice(samples['beta'])
         parameters['start_measures'] += pd.Timedelta(days=np.random.triangular(left=0,mode=0,right=21))
         return parameters
 

--- a/tutorials/SIR/workflow_tutorial.py
+++ b/tutorials/SIR/workflow_tutorial.py
@@ -171,9 +171,9 @@ if __name__ == '__main__':
     ##############################
 
     # Define draw function
-    def draw_fcn(param_dict, samples_dict):
-        param_dict['beta'] = np.random.choice(samples_dict['beta'])
-        return param_dict
+    def draw_fcn(parameters, samples):
+        parameters['beta'] = np.random.choice(samples_dict['beta'])
+        return parameters
     # Simulate model
     out = model.sim([start_date, end_date+pd.Timedelta(days=2*28)], N=100, samples=samples_dict, draw_function=draw_fcn, processes=processes)
     # Add negative binomial observation noise
@@ -205,10 +205,10 @@ if __name__ == '__main__':
             return param/2
 
     # Define draw function
-    def draw_fcn(param_dict, samples_dict):
-        param_dict['beta'] = np.random.choice(samples_dict['beta'])
-        param_dict['start_measures'] += pd.Timedelta(days=np.random.triangular(left=0,mode=0,right=21))
-        return param_dict
+    def draw_fcn(parameters, samples):
+        parameters['beta'] = np.random.choice(samples_dict['beta'])
+        parameters['start_measures'] += pd.Timedelta(days=np.random.triangular(left=0,mode=0,right=21))
+        return parameters
 
     # Attach its arguments to the parameter dictionary
     model.parameters.update({'start_measures': end_date})

--- a/tutorials/SIR_SI/calibration.py
+++ b/tutorials/SIR_SI/calibration.py
@@ -142,10 +142,10 @@ if __name__ == '__main__':
 
     # Define draw function
     import random
-    def draw_fcn(param_dict, samples_dict):
-        idx, param_dict['beta'] = random.choice(list(enumerate(samples_dict['beta'])))
-        param_dict['alpha'] = np.array([slice[idx] for slice in samples_dict['alpha']])
-        return param_dict
+    def draw_fcn(parameters, samples):
+        idx, parameters['beta'] = random.choice(list(enumerate(samples['beta'])))
+        parameters['alpha'] = np.array([slice[idx] for slice in samples['alpha']])
+        return parameters
     # Simulate model
     N = 50
     out = model.sim([start_date, end_date+60], N=N, samples=samples_dict, draw_function=draw_fcn, processes=processes)

--- a/tutorials/enzyme_kinetics/calibrate_intrinsic_kinetics.py
+++ b/tutorials/enzyme_kinetics/calibrate_intrinsic_kinetics.py
@@ -140,13 +140,13 @@ if __name__ == '__main__':
     ## Visualize result ##
     ######################
 
-    def draw_fcn(param_dict, samples_dict):
-        idx, param_dict['Vf_Ks'] = random.choice(list(enumerate(samples_dict['Vf_Ks'])))
-        param_dict['R_AS'] = samples_dict['R_AS'][idx]
-        param_dict['R_AW'] = samples_dict['R_AW'][idx]
-        param_dict['R_Es'] = samples_dict['R_Es'][idx]
-        param_dict['K_eq'] = samples_dict['K_eq'][idx]
-        return param_dict
+    def draw_fcn(parameters, samples):
+        idx, parameters['Vf_Ks'] = random.choice(list(enumerate(samples['Vf_Ks'])))
+        parameters['R_AS'] = samples['R_AS'][idx]
+        parameters['R_AW'] = samples['R_AW'][idx]
+        parameters['R_Es'] = samples['R_Es'][idx]
+        parameters['K_eq'] = samples['K_eq'][idx]
+        return parameters
 
     # Loop over datasets
     for i,df in enumerate(data):

--- a/tutorials/enzyme_kinetics/simulate_1D_PFR.py
+++ b/tutorials/enzyme_kinetics/simulate_1D_PFR.py
@@ -38,13 +38,13 @@ f = open(os.path.join(os.path.dirname(__file__),'data/username_SAMPLES_2023-06-0
 samples_dict = json.load(f)
 
 # Define draw function
-def draw_fcn(param_dict, samples_dict):
-    idx, param_dict['Vf_Ks'] = random.choice(list(enumerate(samples_dict['Vf_Ks'])))
-    param_dict['R_AS'] = samples_dict['R_AS'][idx]
-    param_dict['R_AW'] = samples_dict['R_AW'][idx]
-    param_dict['R_Es'] = samples_dict['R_Es'][idx]
-    param_dict['K_eq'] = samples_dict['K_eq'][idx]
-    return param_dict
+def draw_fcn(parameters, samples):
+    idx, parameters['Vf_Ks'] = random.choice(list(enumerate(samples['Vf_Ks'])))
+    parameters['R_AS'] = samples['R_AS'][idx]
+    parameters['R_AW'] = samples['R_AW'][idx]
+    parameters['R_Es'] = samples['R_Es'][idx]
+    parameters['K_eq'] = samples['K_eq'][idx]
+    return parameters
 
 ###################
 ## Load the data ##

--- a/tutorials/influenza_1718/calibration.py
+++ b/tutorials/influenza_1718/calibration.py
@@ -217,11 +217,11 @@ if __name__ == '__main__':
     ######################
  
     # Define draw function
-    def draw_fcn(param_dict, samples_dict):
+    def draw_fcn(parameters, samples):
         # Sample model parameters
-        idx, param_dict['beta'] = random.choice(list(enumerate(samples_dict['beta'])))
-        param_dict['f_ud'] = np.array([slice[idx] for slice in samples_dict['f_ud']])
-        return param_dict
+        idx, parameters['beta'] = random.choice(list(enumerate(samples['beta'])))
+        parameters['f_ud'] = np.array([slice[idx] for slice in samples['f_ud']])
+        return parameters
     # Simulate model
     out = model.sim([start_visualisation, end_visualisation], N=n, tau=tau, output_timestep=1, samples=samples_dict, draw_function=draw_fcn, processes=processes)
     # Add negative binomial observation noise


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

## Name change 

A draw function must from hereon be defined as follows,
```python
def draw_function(parameters, samples):
    # do something
    return parameters
```

Instead of,

```python
def draw_function(param_dict, samples_dict):
    # do something
    return param_dict
```

This is a minor update but it will break all user's code that uses the old convention.

## Future

Because the argument `samples` is a dictionary, you can technically pass any input you'd like to a draw function. So I'm thinking `samples` should be generalized into an optional argument of the `sim` method named `draw_function_kwargs`. It should then be possible for a user to define a draw function like this,

```python
def draw_function(parameters, input_1, input_2):
    # do something
    return parameters
```

To run the model,

```python
model.sim(100, draw_function=draw_function, draw_function_kwargs={'input_1': 5, 'input_2': 10})
```

Or if the user doesn't want any inputs to his draw function,
```python
def draw_function(parameters):
    # do something
    return parameters
```

To run the model,

```python
model.sim(100, draw_function=draw_function)
```
