### PR TITLE
Change name of tutorial conda environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The [enzyme kinetics](enzyme_kinetics.md) and [influenza 17-18](influenza_1718.m
     - Version 0.2.4 (2023-12-04, PR #62)
         > Validated the use of Python 3.11. Efficiency gains in simulation of jump processes. Ommitted dependency on Numba. All changes related to publishing our software manuscript in Journal of Computational Science. Improved nomenclature in model defenition.
     - IN PROGRESS: 0.2.5
-        > Validated the use of Python 3.12. Validated pySODM on macOS Sonoma 14.5. Input arguments of 'draw functions' must now be named 'parameters' and 'samples' instead of 'param_dict' and 'samples_dict'.
+        > Validated the use of Python 3.12. Validated pySODM on macOS Sonoma 14.5. 'draw functions' only have 'parameters' as mandatory input, followed by an arbitrary number of additional parameters (PR #75). Tutorial environment can now be found in `tutorial_env.yml` and was renamed `PYSODM-TUTORIALS` (PR #76).
 - Version 0.1 (2022-12-23, PR #14)
     > Application pySODM to three use cases. Documentation website. Unit tests for ODE, JumpProcess and calibration. 
     - Version 0.1.1 (2023-01-09, PR #20)

--- a/docs/enzyme_kinetics.md
+++ b/docs/enzyme_kinetics.md
@@ -23,7 +23,7 @@ This part of the tutorial can be replicated by running
 ```bash
 python calibrate_intrinsic_kinetics.py
 ```
-located in `~/tutorials/enzyme_kinetics/`.
+located in `~/tutorials/enzyme_kinetics/`. An environment containing the dependencies needed to run this tutorial is provided in `~/tutorial_env.yml`.
 
 ### Experiments and model equations
 

--- a/docs/influenza_1718.md
+++ b/docs/influenza_1718.md
@@ -13,7 +13,7 @@ This tutorial can be replicated by running
 ```bash
 python calibration.py
 ```
-located in `~/tutorials/influenza_1718/`.
+located in `~/tutorials/influenza_1718/`. An environment containing the dependencies needed to run this tutorial is provided in `~/tutorial_env.yml`.
 
 ## Data
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,9 +73,9 @@ Installing pySODM from pyPI does not give you acces to the tutorials and case st
 - On the [pySODM Github repository page](https://github.com/twallema/pySODM) click the `Fork` button.
 - From your own repository page (your account) of `pySODM`, use [`git`](https://git-scm.com/) to download the code to your own computer. See the [Github documentation](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) on how to clone/download a repository.
 
-When all went fine, you should have the code on your computer in a directory called `pySODM`. This folder contains an `environment.yml` file containing all the dependencies necessary to recreate the tutorials and case studies. Install pySODM in this environment with the development requirements (necessary to work on the documentation),
+When all went fine, you should have the code on your computer in a directory called `pySODM`. This folder contains a file `tutorials_env.yml` containing all the dependencies necessary to recreate the tutorials on this website. Install pySODM in this environment with the development requirements (necessary to work on the documentation),
 ```
-conda env create -f environment.yml
+conda env create -f tutorials_env.yml
 conda activate PYSODM
 pip install -e ".[develop]"
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,14 +56,14 @@ Installing pySODM from pyPI does not give you acces to the tutorials and case st
 
 - Download the [source code](https://github.com/twallema/pySODM) from GitHub. When all went fine, you should have the code on your computer in a directory called `pySODM`.
 
-- An environment with the dependencies for the tutorials is available inside the `~/environment.yml` file (environment name: PYSODM). Open a terminal in the root folder and create the PYSODM environment:
+- An environment with the dependencies for the tutorials is available inside the `~/tutorial_env.yml` file (environment name: PYSODM-TUTORIALS). Open a terminal in the root folder and create the PYSODM environment:
      ```
-     conda env create -f environment.yml
+     conda env create -f tutorial_env.yml
      ```
 
 - Activate the environment and install pySODM from source in it:
      ```
-     conda activate PYSODM
+     conda activate PYSODM-TUTORIALS
      pip install -e.
      ```
 
@@ -75,7 +75,7 @@ Installing pySODM from pyPI does not give you acces to the tutorials and case st
 
 When all went fine, you should have the code on your computer in a directory called `pySODM`. This folder contains a file `tutorials_env.yml` containing all the dependencies necessary to recreate the tutorials on this website. Install pySODM in this environment with the development requirements (necessary to work on the documentation),
 ```
-conda env create -f tutorials_env.yml
-conda activate PYSODM
+conda env create -f tutorial_env.yml
+conda activate PYSODM-TUTORIALS
 pip install -e ".[develop]"
 ```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -10,7 +10,7 @@ In this tutorial, we'll use the simple SIR disease model without dimensions from
 6. Visualize the goodness-of-fit
 7. Perform a scenario analysis
 
-By using a simple model, we can focus on the general workflow and on the most important functions of pySODM, which will be similar in the more advanced [enzyme kinetics](enzyme_kinetics.md) and [Influenza](influenza_1718.md) case studies available on this documentation website. This tutorial can be reproduced by running `~/tutorials/SIR/workflow_tutorial.py`
+By using a simple model, we can focus on the general workflow and on the most important functions of pySODM, which will be similar in the more advanced [enzyme kinetics](enzyme_kinetics.md) and [Influenza](influenza_1718.md) case studies available on this documentation website. This tutorial can be reproduced by running `~/tutorials/SIR/workflow_tutorial.py`, an environment containing the dependencies needed to run this tutorial is provided in `~/tutorial_env.yml`.
 
 ### Import dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         'matplotlib',
         'xarray',
         'emcee',
-        'h5py'
+        'h5py',
+        'tqdm'
     ],
     extras_require={
         "develop":  ["pytest",

--- a/tutorial_env.yml
+++ b/tutorial_env.yml
@@ -9,3 +9,4 @@ dependencies:
   - xarray
   - matplotlib
   - corner
+  - numba

--- a/tutorial_env.yml
+++ b/tutorial_env.yml
@@ -1,4 +1,4 @@
-name: PYSODM
+name: PYSODM-TUTORIALS
 channels:
   - conda-forge
   - defaults
@@ -6,11 +6,6 @@ dependencies:
   - python=3.12
   - pandas
   - numpy
-  - scipy
-  - numba   
   - xarray
   - matplotlib
-  - emcee
-  - h5py  
-  - tqdm
   - corner


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

Filename has been changed to be more descriptive: `environment.yml` --> `tutorial_env.yml`
Environment name has been changed to be more descriptive: `PYSODM` --> `PYSODM-TUTORIALS`

@RitaVazVerstraeten Will only apply if working with an up-to-date fork of the pySODM GitHub repository. Changes will come into effect on pyPI starting version 0.2.5.