### PR TITLE
Update local docs build commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         pip install -e."[develop]"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy documentation website
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Run unit tests
 
 on:
   push:
@@ -17,12 +17,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .[develop]
-    - name: Build
+    - name: Run unit tests
       run: |
         pytest src/tests/test_ODE.py
         pytest src/tests/test_JumpProcess.py

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -66,9 +66,9 @@ Documentation consists of both the technical matter about the code as well as ba
 
 The Sphinx setup provides the usage of both `.rst` file, i.e. [restructuredtext](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html) as well as `.md` files, i.e. [Markdown](https://www.markdownguide.org/basic-syntax/). The latter is generally experienced as easier to write, while the former provides more advanced functionalities. Existing pages of the documentation reside in `~/docs/` and can be adjusted directly. In case you want to build the documentation locally, make sure you have the development dependencies installed (`pip install -e ".[develop]"`) to run the sphinx build script. To build locally, run the following command in the home directory,
 ```bash
-python setup.py build_sphinx
+python sphinx-build docs build/sphinx/
 ```
-which compiles the html-website in the directory `build/html`. Double click any of the `html` file in the folder to open the website in your browser (no server required). Or alternatively, run the following command in the 'docs' directory,
+which compiles the html-website in the directory `build/sphinx/html`. Double click any of the `html` file in the folder to open the website in your browser (no server required). Or alternatively, run the following command in the 'docs' directory,
 ```bash
 make html
 ```


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In `.github/workflows/deploy.yml` the documentation website was setup to recompile on every push. If a branch was not up-to-date with the most current documentation, this would revert the documentation back to an old version if the user pushed one of his commits from his local branch. 

Now it should only update the documentation when a PR is happening. 

Also found the command that runs sphinx locally and updated it in the docs.