### PR TITLE
remove if: github.event_name == 'push' from deploy docs workflow file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,3 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/sphinx/
-      if: github.event_name == 'push'


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [ ] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

Removed last line from `.github/workflows/deploy.yml`,

```yaml
if: github.event_name == 'push'
```

I think this may prevent the gh-pages from updating when doing a PR.