### PR TITLE
Allow uniform priors to handle infinite bounds --> equivalent to having "no prior"

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -136,7 +136,7 @@ def log_prior_uniform(x, bounds):
     prob = 1/(bounds[1]-bounds[0])
     condition = bounds[0] <= x <= bounds[1]
     if condition == True:
-        # Can also be set to zero: value doesn't matter much because its constant --> should be set to zero, bounds = np.inf --> prob is inf!!!
+        # should be set to zero to accomodate bounds = np.inf --> prob is inf!!!
         return 0
     else:
         return -np.inf

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -136,8 +136,8 @@ def log_prior_uniform(x, bounds):
     prob = 1/(bounds[1]-bounds[0])
     condition = bounds[0] <= x <= bounds[1]
     if condition == True:
-        # Can also be set to zero: value doesn't matter much because its constant
-        return np.log(prob)
+        # Can also be set to zero: value doesn't matter much because its constant --> should be set to zero, bounds = np.inf --> prob is inf!!!
+        return 0
     else:
         return -np.inf
 


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In `src/pySODM/optimization/objective_functions.py`, the uniform prior probability was implemented as follows,

```python
def log_prior_uniform(x, bounds):
    """ Uniform log prior distribution """
    prob = 1/(bounds[1]-bounds[0])
    condition = bounds[0] <= x <= bounds[1]
    if condition == True:
        # should be set to zero to accomodate bounds = np.inf --> prob is inf!!!
        return np.log(prob)
    else:
        return -np.inf
```

which, when given an infinite bound (i.e. having no physical bound to the parameter) returned an error because `prob --> 0`, so `np.log(prob) --> inf`.

As we are taking the log sum of the prior probabilities and likelihood, the value of this probability does not influence the location of the maximal log posterior probability, so I've changed this to simply returning a probability of zero,

```python
def log_prior_uniform(x, bounds):
    """ Uniform log prior distribution """
    prob = 1/(bounds[1]-bounds[0])
    condition = bounds[0] <= x <= bounds[1]
    if condition == True:
        # should be set to zero to accomodate bounds = np.inf --> prob is inf!!!
        return 0
    else:
        return -np.inf
```