### PR TITLE
Manual seeding randomness in JumpProcess class using "fork" multiprocessing

### DIFF
--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -367,11 +367,12 @@ class JumpProcess:
 
         return _output_to_xarray_dataset(output, self.state_shapes, self.dimensions_per_state, self.state_coordinates, actual_start_date)
 
-    def _mp_sim_single(self, drawn_parameters, time, actual_start_date, method, tau, output_timestep):
+    def _mp_sim_single(self, drawn_parameters, seed, time, actual_start_date, method, tau, output_timestep):
         """
         A Multiprocessing-compatible wrapper for _sim_single, assigns the drawn dictionary and runs _sim_single
         """
         self.parameters.update(drawn_parameters)
+        np.random.seed(seed)
         return self._sim_single(time, actual_start_date, method, tau, output_timestep)
 
     def sim(self, time, warmup=0, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='tau_leap', tau=0.5, output_timestep=1):
@@ -459,12 +460,13 @@ class JumpProcess:
 
         # Run simulations
         if processes: # Needed 
-            with get_context("fork").Pool(processes) as p:
-                output = p.map(partial(self._mp_sim_single, time=time, actual_start_date=actual_start_date, method=method, tau=tau, output_timestep=output_timestep), drawn_dictionaries)
+            with get_context("fork").Pool(processes) as p:      # 'fork' instead of 'spawn' to run on Apple Silicon
+                seeds = np.random.randint(0, 2**32, size=N)     # requires manual reseeding of the random number generators used in the stochastic algorithms in every child process
+                output = p.starmap(partial(self._mp_sim_single, time=time, actual_start_date=actual_start_date, method=method, tau=tau, output_timestep=output_timestep), zip(drawn_dictionaries, seeds))
         else:
             output=[]
             for dictionary in drawn_dictionaries:
-                output.append(self._mp_sim_single(dictionary, time, actual_start_date, method=method, tau=tau, output_timestep=output_timestep))
+                output.append(self._mp_sim_single(dictionary, np.random.randint(0, 2**32, size=1), time, actual_start_date, method=method, tau=tau, output_timestep=output_timestep))
 
         # Append results
         out = output[0]


### PR DESCRIPTION
…essing pool

<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In a previous PR #70, the multiprocessing pool used to distribute multiple simulations across cores was switched from initialization method "spawn" to "fork" because "spawn" did not work on Apple Silicon. 

However, using the method "fork" makes the child process inherent its parents random seed. When simulating a stochastic model using the `JumpProcess` class this eliminates randomness from the simulation algorithm of a stochastic model as the seed is always identical.

This behavior is not desired and is therefore rectified in this PR by drawing the random seed and passing it on explicitly to the children.

```python
# Run simulations
if processes:
    with get_context("fork").Pool(processes) as p:      # 'fork' instead of 'spawn' to run on Apple Silicon
        seeds = np.random.randint(0, 2**32, size=N)     # requires manual reseeding of the random number generators used in the stochastic algorithms in every child process
        output = p.starmap(partial(self._mp_sim_single, time=time, actual_start_date=actual_start_date, method=method, tau=tau, output_timestep=output_timestep), zip(drawn_dictionaries, seeds))
else:
    output=[]
    for dictionary in drawn_dictionaries:
        output.append(self._mp_sim_single(dictionary, np.random.randint(0, 2**32, size=1), time, actual_start_date, method=method, tau=tau, output_timestep=output_timestep))
```

No bug fix was applied to the `ODE` class as there is no inherent randomness to these simulations. 