### PR TITLE
Use nplog1p in poisson/negbinom likelihood function

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -58,18 +58,9 @@ def ll_poisson(ymodel, ydata):
         Loglikelihood belonging to the comparison of the data points and the model prediction.
     """
 
-    # Convert datatype to float
-    ymodel = ymodel.astype('float64')
-    ydata = ydata.astype('float64')
-    # Raise ymodel or ydata if there are negative values present
-    if ((np.min(ymodel) < 0) | (np.min(ydata) < 0)):
-        offset_value = (-1 - 1e-6)*np.min([np.min(ymodel), np.min(ydata)])
-        ymodel += offset_value
-        ydata += offset_value
-        #warnings.warn(f"One or more values in the prediction were negative thus the prediction was offset, minimum predicted value: {min(ymodel)}")
-    elif ((np.min(ymodel) == 0) | (np.min(ydata) == 0)):
-        ymodel += 1e-6
-        ydata += 1e-6
+    # Convert datatype to float and add one
+    ymodel = ymodel.astype('float64') + 1
+    ydata = ydata.astype('float64') + 1
 
     return - np.sum(ymodel) + np.sum(ydata*np.log(ymodel)) - np.sum(gammaln(ydata))
 

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -272,7 +272,7 @@ class log_posterior_probability():
         if weights is None:
             if any(len(lst) != len(data) for lst in [states, log_likelihood_fnc, log_likelihood_fnc_args]):
                 raise ValueError(
-                    "The number of datasets ({0}), model states ({1}), log likelihood functions ({2}), and the extra arguments of the log likelihood function ({3}) must be of equal".format(len(data),len(states), len(log_likelihood_fnc), len(log_likelihood_fnc_args))
+                    "The number of datasets ({0}), model states ({1}), log likelihood functions ({2}), and the extra arguments of the log likelihood function ({3}) must be of equal length".format(len(data),len(states), len(log_likelihood_fnc), len(log_likelihood_fnc_args))
                     )
             else:
                 weights = len(data)*[1,]
@@ -280,7 +280,7 @@ class log_posterior_probability():
         if not initial_states:
             if any(len(lst) != len(data) for lst in [states, log_likelihood_fnc, weights, log_likelihood_fnc_args]):
                 raise ValueError(
-                    "The number of datasets ({0}), model states ({1}), log likelihood functions ({2}), the extra arguments of the log likelihood function ({3}), and weights ({4}) must be of equal".format(len(data),len(states), len(log_likelihood_fnc), len(log_likelihood_fnc_args), len(weights))
+                    "The number of datasets ({0}), model states ({1}), log likelihood functions ({2}), the extra arguments of the log likelihood function ({3}), and weights ({4}) must be of equal length".format(len(data),len(states), len(log_likelihood_fnc), len(log_likelihood_fnc_args), len(weights))
                     )
         else:
             # Validate initial states
@@ -289,7 +289,7 @@ class log_posterior_probability():
             # Check 
             if any(len(lst) != len(data) for lst in [states, log_likelihood_fnc, weights, log_likelihood_fnc_args, initial_states]):
                 raise ValueError(
-                    "The number of datasets ({0}), model states ({1}), log likelihood functions ({2}), the extra arguments of the log likelihood function ({3}), weights ({4}) and initial states ({5}) must be of equal".format(len(data),len(states), len(log_likelihood_fnc), len(log_likelihood_fnc_args), len(weights), len(initial_states))
+                    "The number of datasets ({0}), model states ({1}), log likelihood functions ({2}), the extra arguments of the log likelihood function ({3}), weights ({4}) and initial states ({5}) must be of equal length".format(len(data),len(states), len(log_likelihood_fnc), len(log_likelihood_fnc_args), len(weights), len(initial_states))
                     )
         self.initial_states = initial_states
 

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -86,21 +86,13 @@ def ll_negative_binomial(ymodel, ydata, alpha):
     ll: float
         Loglikelihood belonging to the comparison of the data points and the model prediction.
     """
-
+    
     # Expand first dimensions on 'alpha' to match the axes
     alpha = np.array(alpha)[np.newaxis, ...]
-    # Convert datatype to float
-    ymodel = ymodel.astype('float64')
-    ydata = ydata.astype('float64')
-    # Raise ymodel or ydata if there are negative values present
-    if ((np.min(ymodel) < 0) | (np.min(ydata) < 0)):
-        offset_value = (-1 - 1e-6)*np.min([np.min(ymodel), np.min(ydata)])
-        ymodel += offset_value
-        ydata += offset_value
-        #warnings.warn(f"One or more values in the prediction were negative thus the prediction was offset, minimum predicted value: {min(ymodel)}")
-    elif ((np.min(ymodel) == 0) | (np.min(ydata) == 0)):
-        ymodel += 1e-6
-        ydata += 1e-6
+
+    # Convert datatype to float and add one
+    ymodel = ymodel.astype('float64') + 1 
+    ydata = ydata.astype('float64') + 1
 
     return np.sum(ydata*np.log(ymodel)) - np.sum((ydata + 1/alpha)*np.log(1+alpha*ymodel)) + np.sum(ydata*np.log(alpha)) + np.sum(gammaln(ydata+1/alpha)) - np.sum(gammaln(ydata+1))- np.sum(ydata.shape[0]*gammaln(1/alpha))
 

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -3,10 +3,9 @@ import itertools
 import pandas as pd
 import numpy as np
 import xarray as xr
-from scipy.stats import norm, weibull_min, triang, gamma
+from scipy.stats import norm, triang, gamma
 from scipy.special import gammaln
 from pySODM.models.utils import list_to_dict
-from pySODM.optimization.utils import _thetas_to_thetas_dict
 from pySODM.models.validation import validate_initial_states
 
 ##############################

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -14,7 +14,7 @@ from pySODM.models.validation import validate_initial_states
 
 def ll_gaussian(ymodel, ydata, sigma):
     """
-    Loglikelihood of a Gaussian distribution, can be used homoskedastically or heteroskedastically.
+    Loglikelihood of a Gaussian distribution, can be used homoskedastically (one sigma for the entire timeseries) or heteroskedastically (one sigma per datapoint in the timeseries).
 
     Parameters
     ----------


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

In `ll_poisson` and `ll_negative_binomial`, there was a test to see if the `ydata` or `ymodel` were smaller than or equal to one. If this was the case, then the minimal model/data point were found and raised to 1e-6. This is,

1. Unnecessarily complex, you can just add one to both `ymodel` and `ydata`.
2. May actually introduce bias, because a log of a small number tends to negative infinity.

So now, by default, in `ll_poisson` and `ll_negative_binomial`,

```python
ymodel += 1
data += 1
```

I've verified this gives the same results in the workflow & influenza 17-18 tutorial.