### PR TITLE
Change to 50% KDE move, 25% DE move, 25% DESnookermove for more mobile chains

### DIFF
--- a/src/pySODM/optimization/mcmc.py
+++ b/src/pySODM/optimization/mcmc.py
@@ -12,7 +12,7 @@ from pySODM.optimization.visualization import traceplot, autocorrelation_plot
 abs_dir = os.path.dirname(__file__)
 
 def run_EnsembleSampler(pos, max_n, identifier, objective_function, objective_function_args=None, objective_function_kwargs=None,
-                        moves=[(emcee.moves.DEMove(), 0.50),(emcee.moves.DESnookerMove(),0.25),(emcee.moves.KDEMove(bw_method='scott'), 0.25)],
+                        moves=[(emcee.moves.DEMove(), 0.25),(emcee.moves.DESnookerMove(),0.25),(emcee.moves.KDEMove(bw_method='scott'), 0.50)],
                         fig_path=None, samples_path=None, print_n=10, backend=None, processes=1, progress=True, settings_dict={}):
     """Wrapper function to setup an `emcee.EnsembleSampler` and handle all backend-related tasks.
     
@@ -42,7 +42,7 @@ def run_EnsembleSampler(pos, max_n, identifier, objective_function, objective_fu
     Hyperparameters:
     ----------------
         moves: list
-            Consult the [emcee documentation](https://emcee.readthedocs.io/en/stable/user/moves/).
+            Algorithm used for updating the coordinates of walkers in an ensemble sampler. By default, pySODM uses a differential evolution move 25% of the time, a differential evolution snooker move 25% of the time, and a kernel-density estimate move 50% of the time. Consult the [emcee documentation](https://emcee.readthedocs.io/en/stable/user/moves/).
         backend: emcee.backends.HDFBackend
             Backend of a previous sampling experiment. If a backend is provided, the sampler is restarted from the last iteration of the previous run. Consult the [emcee documentation](https://emcee.readthedocs.io/en/stable/user/backends/).
         progress: bool


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

New ratios of `emcee` moves:

- 50% KDE move
- 25% DE move
- 25% DE snooker move