### PR TITLE
Enable retaining floats in function list_to_dict in log posterior probability function

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -469,7 +469,7 @@ class log_posterior_probability():
                 thetas[i] = self.expanded_bounds[i][0]
 
         # Unflatten thetas
-        thetas_dict = list_to_dict(thetas, self.parameter_shapes)
+        thetas_dict = list_to_dict(thetas, self.parameter_shapes, retain_floats=True)
 
         # Assign and remove warmup
         if 'warmup' in thetas_dict.keys():


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have updated the documentation accordingly.

Describe your fixes/additions/changes

Calibrated parameters

In #84 the default behavior of `list_to_dict` when encountering a float was changed to `retain_floats=False` bc this made more sense in the context of simulations. However, `list_to_dict` is also used in the computation of the log posterior probability and there it makes more sense to have `retain_floats = True`. 

This PR changes the behavior of the `list_to_dict` called in the log posterior probability function to `retain_floats=True`. The default setting however remains `retain_floats=False`.