### PR TITLE
Add the option to manually define the simulation start when calibrating a model

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -4,22 +4,23 @@
 
 ### Log posterior probability
 
-***class* log_posterior_probability(model, parameter_names, bounds, data, states, log_likelihood_fnc, log_likelihood_fnc_args, weights=None, log_prior_prob_fnc=None, log_prior_prob_fnc_args=None, initial_states=None, aggregation_function=None, labels=None)**
+***class* log_posterior_probability(model, parameter_names, bounds, data, states, log_likelihood_fnc, log_likelihood_fnc_args, start_sim=None, weights=None, log_prior_prob_fnc=None, log_prior_prob_fnc_args=None, initial_states=None, aggregation_function=None, labels=None)**
 
 **Parameters:**
 
-* **model** (object) - An initialized ODE or JumpProcess.
+* **model** (object) - An initialized `pySODM.models.base.ODE` or `pySODM.models.base.JumpProcess` model.
 * **parameter_names** (list) - Names of model parameters (type: str) to calibrate. Model parameters must be of type float (0D), list containing float (1D), or np.ndarray (nD).
-* **bounds** (list) - Lower and upper bound of calibrated parameters provided as lists/tuples containing lower and upper bound: example: `[(lb_1, ub_1), ..., (lb_n, ub_n)]`. Values falling outside these bounds will be restricted to the provided ranges before simulating the model.
-* **data** (list) - Contains the datasets (type: pd.Series/pd.DataFrame) the model should be calibrated to. For one dataset use `[dataset,]`. Must contain a time index named `time` or `date`. Additional axes must be implemented using a `pd.Multiindex` and must bear the names/contain the coordinates of a valid model dimension.
-* **states** (list) - Names of the model states (type: str) the respective datasets should be matched to.
-* **log_likelihood_fnc** (list) - Contains a log likelihood function for every provided dataset.
-* **log_likelihood_fnc_args** (list) - Contains the arguments of the log likelihood functions. If the log likelihood function has no arguments (`ll_poisson`), provide an empty list.
+* **bounds** (list) - Lower and upper bound of calibrated parameters. Provided as a list or tuple containing lower and upper bound: example: `bounds = [(lb_1, ub_1), ..., (lb_n, ub_n)]`.
+* **data** (list) - Contains the datasets (type: pd.Series/pd.DataFrame) the model should be calibrated to. If there is only one dataset use `data = [df,]`. Dataframe must contain an index named `time` or `date`. Stratified data can be incorporated using a `pd.Multiindex`, whose index levels must have names corresponding to valid model dimensions, and whose indices must be valid dimension coordinates.
+* **states** (list) - Names of the model states (type: str) the respective datasets should be matched to. Must have the same length as `data`.
+* **log_likelihood_fnc** (list) - Contains a log likelihood function for every provided dataset. Must have the same length as `data`.
+* **log_likelihood_fnc_args** (list) - Contains the arguments of the log likelihood functions. If the log likelihood function has no arguments (such as `ll_poisson`), provide an empty list. Must have the same length as `data`.
+* **start_sim** (int/float or str/datetime) - optional - Can be used to alter the start of the simulation. By default, the start of the simulation is chosen as the earliest time/date found in the datasets. 
 * **weights** (list) - optional - Contains the weights of every dataset in the final log posterior probability. Defaults to one for every dataset.
 * **log_prior_prob_fnc** (list) - optional - Contains a prior probability function for every calibrated parameter. Defaults to a uniform prior using the provided bounds.
 * **log_prior_prob_fnc_args** (list) - optional - Contains the arguments of the provided prior probability functions.
-* **initial_states** (list) - optional - Contains a dictionary of initial states for every dataset. 
-* **aggregation_function** (callable function or list) - optional - A user-defined function to manipulate the model output before matching it to data. The function takes as input an `xarray.DataArray`, resulting from selecting the simulation output at the state we wish to match to the dataset (`model_output_xarray_Dataset['state_name']`), as its input. The output of the function must also be an `xarray.DataArray`. No checks are performed on the input or output of the aggregation function, use at your own risk. Illustrative use case: I have a spatially explicit epidemiological model and I desire to simulate it a high spatial resolutioni. However, data is only available on a lower level of spatial resolution. Hence, I use an aggregation function to properly aggregate the spatial levels. I change the coordinates on the spatial dimensions in the model output. Valid inputs for the argument `aggregation_function`are: 1) one callable function --> applied to every dataset. 2) A list containing one callable function --> applied to every dataset. 3) A list containing a callable function for every dataset --> every dataset has its own aggregation function.
+* **initial_states** (list) - optional - Contains a dictionary of initial states for every dataset.
+* **aggregation_function** (callable function or list) - optional - A user-defined function to manipulate the model output before matching it to data. The function takes as input an `xarray.DataArray`, resulting from selecting the simulation output at the state we wish to match to the dataset (`model_output_xarray_Dataset['state_name']`), as its input. The output of the function must also be an `xarray.DataArray`. No checks are performed on the input or output of the aggregation function, use at your own risk. Illustrative use case: I have a spatially explicit epidemiological model and I desire to simulate it a fine spatial resolution. However, data is only available on a coarser level. Hence, I use an aggregation function to properly aggregate the spatial levels. I change the coordinates on the spatial dimensions in the model output. Valid inputs for the argument `aggregation_function`are: 1) one callable function --> applied to every dataset. 2) A list containing one callable function --> applied to every dataset. 3) A list containing a callable function for every dataset --> every dataset has its own aggregation function.
 * **labels** (list) - optional - Contains a custom label for the calibrated parameters. Defaults to the names provided in `parameter_names`.
 
 **Methods:**

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -56,7 +56,7 @@ out = model.sim(121)
 # String representation of dates: 'yyyy-mm-dd' only
 out = model.sim(['2022-12-01', '2023-05-01'])
 
-# Datetime representation of time + dates
+# Datetime representation of time + date
 from datetime import datetime as datetime
 out = model.sim([datetime(2022, 12, 1), datetime(2023, 5, 1)])
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,14 +47,18 @@ To initialize the model, provide a dictionary containing the initial values of t
 model = SIR(states={'S': 1000, 'I': 1}, parameters={'beta': 0.35, 'gamma': 5})
 ```
 
-Simulate the model using its `sim()` method. pySODM supports the use of `datetime` types as timesteps.
+Simulate the model using its `sim()` method. pySODM supports the use of dates to index simulations, string representations of dates with the format `'yyyy-mm-dd'` as well as `datetime.datetime()` can be used. 
 
 ```python
 # Timesteps
 out = model.sim(121)
 
-# Dates
+# String representation of dates: 'yyyy-mm-dd' only
 out = model.sim(['2022-12-01', '2023-05-01'])
+
+# Datetime representation of time + dates
+from datetime import datetime as datetime
+out = model.sim([datetime(2022, 12, 1), datetime(2023, 5, 1)])
 
 # Tailor method and tolerance of integrator
 out = model.sim(121, method='RK45', rtol='1e-4')

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -58,6 +58,66 @@ def validate_simulation_time(time, warmup):
         )
     return time, actual_start_date
 
+def validate_solution_methods_ODE(rtol, method, tau):
+    """
+    Validates the input arguments of the ODE.sim() function
+
+    input
+    -----
+
+    rtol: float
+        Relative solver tolerance
+
+    method: str
+        Solver method: 'RK23', 'RK45', 'DOP853', 'Radau', 'BDF', 'LSODA'
+
+    tau: int/float
+        Discrete integration size of timestep. 
+    """
+
+    if not isinstance(rtol, float):
+        raise TypeError(
+            "relative solver tolerance 'rtol' must be of type float"
+            )
+    if not isinstance(method, str):
+        raise TypeError(
+            "solver method 'method' must be of type string"
+            )
+    if method not in ['RK23', 'RK45', 'DOP853', 'Radau', 'BDF', 'LSODA']:
+        raise ValueError(
+            f"invalid solution method '{method}'. valid methods: 'RK23', 'RK45', 'DOP853', 'Radau', 'BDF', 'LSODA'"
+        )
+    if tau != None:
+        if not isinstance(tau, (int,float)):
+            raise TypeError(
+                "discrete timestep 'tau' must be of type int or float"
+            )
+
+def validate_solution_methods_JumpProcess(method, tau):
+    """
+    Validates the input arguments of the JumpProcess.sim() function
+
+    method: str
+        Solver method: 'SSA' or 'tau_leap'
+
+    tau: int/float
+        If method == 'tau_leap' --> leap size
+    """
+
+    # Input checks on solution method and timestep
+    if not isinstance(method, str):
+        raise TypeError(
+            "solver method 'method' must be of type string"
+            )
+    if method not in ['tau_leap', 'SSA']:
+        raise ValueError(
+            f"invalid solution method '{method}'. valid methods: 'SSA' and 'tau_leap'"
+        )
+    if not isinstance(tau, (int,float)):
+        raise TypeError(
+            "discrete timestep 'tau' must be of type int or float"
+            )
+    
 def validate_draw_function(draw_function, draw_function_kwargs, parameters):
     """Validates the draw function's input and output. For use in the sim() functions of the ODE and JumpProcess classes (base.py).
     

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -40,7 +40,7 @@ def validate_simulation_time(time, warmup):
                 types = [type(t) for t in time]
                 raise ValueError(
                     "simulation start and stop must have the format: time=[start, stop]."
-                    " 'start' and 'stop' must have the same datatype: int/float, str, or datetime."
+                    " 'start' and 'stop' must have the same datatype: int/float, str ('yyyy-mm-dd'), or datetime."
                     f" mixing of types is not allowed. you supplied: {types} "
                     )
     else:

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -21,7 +21,7 @@ def validate_simulation_time(time, warmup):
         time = [0-warmup, time]
     elif isinstance(time, list):
         if not len(time) == 2:
-            raise ValueError(f"'Time' must be of format: time=[start, stop]. You have supplied: time={time}.")
+            raise ValueError(f"wrong length of list-like simulation start and stop (length: {len(time)}). correct format: time=[start, stop] (length: 2).")
         else:
             # If they are all int or flat (or commonly occuring np.int64/np.float64)
             if all([isinstance(item, (int,float,np.int32,np.float32,np.int64,np.float64)) for item in time]):
@@ -37,26 +37,24 @@ def validate_simulation_time(time, warmup):
                 actual_start_date = time[0] - timedelta(days=warmup)
                 time = [0, date_to_diff(actual_start_date, time[1])]
             else:
+                types = [type(t) for t in time]
                 raise ValueError(
-                    f"List-like input of simulation start and stop must contain either all int/float or all str/datetime, not a combination of the two "
+                    "simulation start and stop must have the format: time=[start, stop]."
+                    " 'start' and 'stop' must have the same datatype: int/float, str, or datetime."
+                    f" mixing of types is not allowed. you supplied: {types} "
                     )
-    elif isinstance(time, (str,datetime)):
-        raise TypeError(
-            "You have only provided one date as input 'time', how am I supposed to know when to start/end this simulation?"
-        )
     else:
         raise TypeError(
-                "Input argument 'time' must be a single number (int or float), a list of format: time=[start, stop], a string representing of a timestamp, or a timestamp"
+                "'time' must be 1) a single int/float representing the end of the simulation, 2) a list of format: time=[start, stop]."
             )
 
     if time[1] < time[0]:
         raise ValueError(
-            "Start of simulation is chronologically after end of simulation"
+            "start of simulation is chronologically after end of simulation"
         )
     elif time[0] == time[1]:
-        # TODO: Might be usefull to just return the initial condition in this case?
         raise ValueError(
-            "Start of simulation is the same as the end of simulation"
+            "start of simulation is the same as the end of simulation"
         )
     return time, actual_start_date
 

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -616,14 +616,18 @@ def validate_simulation_time_lpp(start_sim, time_index, data):
     """
     Determines and validates what the start and end of the simulations should be
 
+    Simulation start: user-defined (start_sim is not None) or earliest time/date found in dataasets
+    Simulation end: always latest time/date found in dataasets
+
     input
     -----
 
-    start_sim: None (default) or int/float (time_index: 'time') or str/datetime  (time_index: 'date')
-        user-defined start of the simulation
+    start_sim: None (default) or int/float or str/datetime (user-defined)
+        None: start of the simulation is set to the earliest time/date found in dataasets
+        int/float or str/datetime: user-defined start of the simulation
 
     time_index: str
-        'time': if float-like time index. 'date': if datetime-like time index.
+        'time': if float-like time index in datasets. 'date': if datetime-like time index in datasets.
 
     data: list
         List containing the datasets.
@@ -632,10 +636,10 @@ def validate_simulation_time_lpp(start_sim, time_index, data):
     ------
 
     start_sim: float (time_index: 'time') or datetime (time_index: 'date')
-        start of the simulations
+        start of simulations. earliest time/date found in dataasets or user-defined
 
     end_sim : idem
-        idem
+        end of simulations. latest time/date found in dataasets
     """
 
     # extract startdate

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -268,7 +268,7 @@ class log_posterior_probability():
     # TODO: fully document docstring
     """
     def __init__(self, model, parameter_names, bounds, data, states, log_likelihood_fnc, log_likelihood_fnc_args,
-                 weights=None, log_prior_prob_fnc=None, log_prior_prob_fnc_args=None, initial_states=None, aggregation_function=None, labels=None):
+                 start_sim=None, weights=None, log_prior_prob_fnc=None, log_prior_prob_fnc_args=None, initial_states=None, aggregation_function=None, labels=None):
 
         ############################################################################################################
         ## Validate lengths of data, states, log_likelihood_fnc, log_likelihood_fnc_args, weights, initial states ##
@@ -314,7 +314,10 @@ class log_posterior_probability():
         # Get additional axes beside time axis in dataset.
         data, self.time_index, self.additional_axes_data = validate_dataset(data)
         # Extract start- and enddate of simulations
-        self.start_sim = min([df.index.get_level_values(self.time_index).unique().min() for df in data])
+        if not start_sim:
+            self.start_sim = min([df.index.get_level_values(self.time_index).unique().min() for df in data])
+        else:
+            self.start_sim = start_sim
         self.end_sim = max([df.index.get_level_values(self.time_index).unique().max() for df in data])
 
         ########################################

--- a/src/tests/test_ODE.py
+++ b/src/tests/test_ODE.py
@@ -1,6 +1,7 @@
 import pytest
 import pandas as pd
 import numpy as np
+from datetime import datetime
 from pySODM.models.base import ODE
 
 #############################
@@ -59,27 +60,27 @@ def test_SIR_time():
 
     # Do it wrong
     # Start before end
-    with pytest.raises(ValueError, match="Start of simulation is chronologically after end of simulation"):
+    with pytest.raises(ValueError, match="start of simulation is chronologically after end of simulation"):
         model.sim([20,5])
 
     # Start same as end
-    with pytest.raises(ValueError, match="Start of simulation is the same as the end of simulation"):
+    with pytest.raises(ValueError, match="start of simulation is the same as the end of simulation"):
         model.sim([0,0])
 
     # Wrong type
-    with pytest.raises(TypeError, match="Input argument 'time' must be a"):
+    with pytest.raises(TypeError, match="a single int/float representing the end of the simulation"):
         model.sim(np.zeros(2))    
 
     # If list: wrong length
-    with pytest.raises(ValueError, match="You have supplied:"):
+    with pytest.raises(ValueError, match="wrong length of list-like simulation start and stop"):
         model.sim([0, 50, 100])    
 
     # Combination of datetime and int/float
-    with pytest.raises(ValueError, match="List-like input of simulation start and stop"):
-        model.sim([0, pd.to_datetime('2020-03-15')])
+    with pytest.raises(ValueError, match="simulation start and stop must have the format:"):
+        model.sim([0, datetime(2020,3,15)])
 
 def test_SIR_date():
-    """Test the use of str/datetime time indexing
+    """ Test the use of str/datetime time indexing
     """
 
     # Define parameters and initial states
@@ -90,7 +91,7 @@ def test_SIR_date():
 
     # Do it right
     output = model.sim(['2020-01-01', '2020-02-20'])
-    output = model.sim([pd.Timestamp('2020-01-01'), pd.Timestamp('2020-02-20')])
+    output = model.sim([datetime(2020,1,1), datetime(2020,2,20)])
 
     # Validate
     assert 'date' in list(output.sizes.keys())
@@ -105,17 +106,25 @@ def test_SIR_date():
     # Do it wrong
 
     # Start before end
-    with pytest.raises(ValueError, match="Start of simulation is chronologically after end of simulation"):
+    with pytest.raises(ValueError, match="start of simulation is chronologically after end of simulation"):
         model.sim(['2020-03-15','2020-03-01'])
 
+    # Start same as end
+    with pytest.raises(ValueError, match="start of simulation is the same as the end of simulation"):
+        model.sim([datetime(2020,1,1),datetime(2020,1,1)])
+
     # Combination of str/datetime
-    with pytest.raises(ValueError, match="List-like input of simulation start and stop must contain either"):
-        model.sim([pd.to_datetime('2020-01-01'), '2020-05-01'])
+    with pytest.raises(ValueError, match="simulation start and stop must have the format:"):
+        model.sim([datetime(2020,1,1), '2020-05-01'])
 
-    # Simulate using a mixture of timestamp and string
-    with pytest.raises(TypeError, match="You have only provided one date as input"):
-        model.sim(pd.to_datetime('2020-01-01'))
+    # string not formatted 'yyyy-mm-dd'
+    with pytest.raises(ValueError, match="time data '2020/03/01' does not match format"):
+        model.sim(['2020/03/01', '2020-05-01'])
 
+    # Only providing one date
+    with pytest.raises(TypeError, match="a single int/float representing the end of the simulation"):
+        model.sim(datetime(2020,1,1))
+ 
 def test_SIR_discrete_stepper():
     """ Test the use of the discrete timestepper, `_solve_discrete()`
     """

--- a/src/tests/test_ODE.py
+++ b/src/tests/test_ODE.py
@@ -59,25 +59,43 @@ def test_SIR_time():
     assert S.shape == (51, )
 
     # Do it wrong
-    # Start before end
+    # dates and times
+    ## Start before end
     with pytest.raises(ValueError, match="start of simulation is chronologically after end of simulation"):
         model.sim([20,5])
 
-    # Start same as end
+    ## Start same as end
     with pytest.raises(ValueError, match="start of simulation is the same as the end of simulation"):
         model.sim([0,0])
 
-    # Wrong type
+    ## Wrong type
     with pytest.raises(TypeError, match="a single int/float representing the end of the simulation"):
         model.sim(np.zeros(2))    
 
-    # If list: wrong length
+    ## If list: wrong length
     with pytest.raises(ValueError, match="wrong length of list-like simulation start and stop"):
         model.sim([0, 50, 100])    
 
-    # Combination of datetime and int/float
+    ## Combination of datetime and int/float
     with pytest.raises(ValueError, match="simulation start and stop must have the format:"):
         model.sim([0, datetime(2020,3,15)])
+
+    # simulation method
+    ## Wrong type for input argument `rtol`
+    with pytest.raises(TypeError, match="relative solver tolerance 'rtol' must be of type float"):
+         model.sim(50, rtol='hello')
+
+    ## Wrong type for input argument `method`
+    with pytest.raises(TypeError, match="solver method 'method' must be of type string"):
+         model.sim(50, method=3)
+
+    ## Right type for input argument 'method' but non-existing method
+    with pytest.raises(ValueError, match="invalid solution method 'bliblablu'. valid methods:"):
+        model.sim(50, method='bliblablu')
+
+    ## Wrong type for discrete timestep 'tau'
+    with pytest.raises(TypeError, match="discrete timestep 'tau' must be of type int or float"):
+        model.sim(50, tau='bliblablu')
 
 def test_SIR_date():
     """ Test the use of str/datetime time indexing
@@ -104,24 +122,24 @@ def test_SIR_date():
     assert S.shape == (51, )
 
     # Do it wrong
-
-    # Start before end
+    # dates and times
+    ## Start before end
     with pytest.raises(ValueError, match="start of simulation is chronologically after end of simulation"):
         model.sim(['2020-03-15','2020-03-01'])
 
-    # Start same as end
+    ## Start same as end
     with pytest.raises(ValueError, match="start of simulation is the same as the end of simulation"):
         model.sim([datetime(2020,1,1),datetime(2020,1,1)])
 
-    # Combination of str/datetime
+    ## Combination of str/datetime
     with pytest.raises(ValueError, match="simulation start and stop must have the format:"):
         model.sim([datetime(2020,1,1), '2020-05-01'])
 
-    # string not formatted 'yyyy-mm-dd'
+    ## string not formatted 'yyyy-mm-dd'
     with pytest.raises(ValueError, match="time data '2020/03/01' does not match format"):
         model.sim(['2020/03/01', '2020-05-01'])
 
-    # Only providing one date
+    ## Only providing one date
     with pytest.raises(TypeError, match="a single int/float representing the end of the simulation"):
         model.sim(datetime(2020,1,1))
  
@@ -579,15 +597,6 @@ def test_draw_function():
     model = SIRstratified(initial_states, parameters, coordinates=coordinates)
     with pytest.raises(ValueError, match="keys in output dictionary of draw function 'draw_function' must match the keys in input dictionary 'parameters'."):
         model.sim(time, draw_function=draw_function, N=5)
-
-    # correct draw function but user does not provide N
-    def draw_function(parameters):
-        return parameters
-    # simulate model
-    time = [0, 10]
-    model = SIRstratified(initial_states, parameters, coordinates=coordinates)
-    with pytest.raises(ValueError, match="you specified a draw function but N=1, have you forgotten 'N'"):
-        model.sim(time, draw_function=draw_function)
 
     # user provides N but no draw function
     with pytest.raises(ValueError, match="attempting to perform N=100 repeated simulations without using a draw function"):

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -74,18 +74,18 @@ def test_weights():
     bounds = [(1e-6,1),]
 
     # Correct: list
-    log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,[1,],labels=labels)
+    log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights=[1,],labels=labels)
     # Correct: np.array
-    log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,np.array([1,]),labels=labels)
+    log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights=np.array([1,]),labels=labels)
     # Incorrect: list of wrong length
     with pytest.raises(ValueError, match="the extra arguments of the log likelihood function"):
-        log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,[1,1],labels=labels)
+        log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights=[1,1],labels=labels)
     # Incorrect: numpy array with more than one dimension
     with pytest.raises(TypeError, match="Expected a 1D np.array for input argument"):
-        log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,np.ones([3,3]),labels=labels)
+        log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights=np.ones([3,3]),labels=labels)
     # Incorrect: datatype string
     with pytest.raises(TypeError, match="Expected a list/1D np.array for input argument"):
-        log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,'hey',labels=labels)
+        log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights='hey',labels=labels)
 
 def test_correct_approach_wo_dimension():
 
@@ -106,7 +106,7 @@ def test_correct_approach_wo_dimension():
     bounds = [(1e-6,1),]
     # Setup objective function without priors and with negative weights 
     objective_function = log_posterior_probability(model,pars,bounds,data,states,
-                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
+                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels)
 
     # PSO
     theta = pso.optimize(objective_function, kwargs={'simulation_kwargs':{'warmup': warmup}},
@@ -125,7 +125,7 @@ def test_correct_approach_wo_dimension():
         fig_path='sampler_output/'
         identifier = 'username'
         # initialize objective function
-        objective_function = log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
+        objective_function = log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels)
         # Perturbate previously obtained estimate
         ndim, nwalkers, pos = perturbate_theta(theta, pert=0.05*np.ones(len(theta)), bounds=objective_function.expanded_bounds, multiplier=multiplier_mcmc)
         # Write some usefull settings to a pickle file (no pd.Timestamps or np.arrays allowed!)
@@ -161,7 +161,7 @@ def break_stuff_wo_dimension():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(Exception, match="is not a valid model parameter!"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # Axes in data not present in model
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -178,7 +178,7 @@ def break_stuff_wo_dimension():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(Exception, match="Your model has no dimensions."):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
     
     # Wrong type of dataset
     # ~~~~~~~~~~~~~~~~~~~~~
@@ -196,7 +196,7 @@ def break_stuff_wo_dimension():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(Exception, match="expected pd.Series, pd.DataFrame"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # pd.DataFrame with more than one column
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -217,7 +217,7 @@ def break_stuff_wo_dimension():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(Exception, match="expected one column."):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
 def break_log_likelihood_functions_wo_dimension():
 
@@ -244,28 +244,28 @@ def break_log_likelihood_functions_wo_dimension():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(ValueError, match="The number of datasets"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # wrong type: float
     log_likelihood_fnc = [ll_poisson,]
     log_likelihood_fnc_args = [alpha,]
     with pytest.raises(ValueError, match="dataset has no extra arguments. Expected an empty list"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # wrong type: list
     log_likelihood_fnc = [ll_poisson,]
     log_likelihood_fnc_args = [[alpha,],]
     with pytest.raises(ValueError, match="dataset has no extra arguments. Expected an empty list"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # wrong type: np.array
     log_likelihood_fnc = [ll_poisson,]
     log_likelihood_fnc_args = [np.array([alpha,]),]
     with pytest.raises(ValueError, match="dataset has no extra arguments. Expected an empty list"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # Negative binomial log likelihood
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -282,7 +282,7 @@ def break_log_likelihood_functions_wo_dimension():
     log_likelihood_fnc_args = [[alpha,]]
     with pytest.raises(ValueError, match="accepted types are int, float, np.ndarray and pd.Series"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
 def test_xarray_datasets():
     """ Test the use of an xarray.DataArray as dataset
@@ -304,7 +304,7 @@ def test_xarray_datasets():
     bounds = [(1e-6,1),]
     # Setup objective function without priors and with negative weights 
     objective_function = log_posterior_probability(model,pars,bounds,data,states,
-                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
+                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels)
 
 class SIR_nd_beta(ODE):
 
@@ -342,7 +342,7 @@ def test_calibration_nd_parameter():
     bounds = [(1e-6,1),]
     # Setup objective function without priors and with negative weights 
     objective_function = log_posterior_probability(model,pars,bounds,data,states,
-                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
+                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels)
     # PSO
     theta = pso.optimize(objective_function,
                         swarmsize=10, max_iter=20, processes=1, debug=True)[0]
@@ -393,7 +393,7 @@ def test_correct_approach_with_one_dimension_0():
     data=[df.groupby(by=['time','age_groups']).sum(),]
     # Setup objective function without priors and with negative weights 
     objective_function = log_posterior_probability(model,pars,bounds,data,states,
-                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
+                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels)
     # Extract formatted parameter_names, bounds and labels
     labels = objective_function.expanded_labels 
     bounds = objective_function.expanded_bounds
@@ -430,7 +430,7 @@ def break_stuff_with_one_dimension():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(Exception, match="0th dataset coordinate 'spatial_units' is"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
     
     # Coordinate in dataset not found in the model
     # Setup model
@@ -443,7 +443,7 @@ def break_stuff_with_one_dimension():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(Exception, match="coordinate '0-20' of dimension 'age_groups' in the 0th"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
 def break_log_likelihood_functions_with_one_dimension():
 
@@ -472,27 +472,27 @@ def break_log_likelihood_functions_with_one_dimension():
     log_likelihood_fnc_args = []
     with pytest.raises(ValueError, match="The number of datasets"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # wrong type: list of incorrect length
     log_likelihood_fnc = [ll_negative_binomial,]
     log_likelihood_fnc_args = [[alpha,]]
     with pytest.raises(ValueError, match="length of list/1D np.array containing arguments of the log likelihood"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # wrong type: np.array of wrong dimensionality
     log_likelihood_fnc = [ll_negative_binomial,]
     log_likelihood_fnc_args = [alpha*np.ones([5,5]), ]
     with pytest.raises(ValueError, match="np.ndarray containing arguments of the log likelihood function"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)    
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)    
 
     # correct type: np.array of right size
     log_likelihood_fnc = [ll_negative_binomial,]
     log_likelihood_fnc_args = [alpha*np.ones([2]), ]
     log_posterior_probability(model,pars,bounds,data,states,
-                                log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)        
+                                log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)        
 
 ####################################
 ## Model with two dimensions ##
@@ -536,7 +536,7 @@ def test_correct_approach_with_two_dimensions():
     data=[df,]
     # Setup objective function without priors and with negative weights 
     objective_function = log_posterior_probability(model,pars,bounds,data,states,
-                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
+                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels)
     # Extract formatted parameter_names, bounds and labels
     pars_postprocessing = objective_function.parameters_names_postprocessing
     labels = objective_function.expanded_labels 
@@ -573,14 +573,14 @@ def test_aggregation_function():
         return output.sum(dim='spatial_units')
     # Correct use
     objective_function = log_posterior_probability(model,pars,bounds,data,states,
-                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels,aggregation_function=aggregation_function)
+                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels,aggregation_function=aggregation_function)
     # Correct use
     objective_function = log_posterior_probability(model,pars,bounds,data,states,
-                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels,aggregation_function=[aggregation_function,])
+                                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels,aggregation_function=[aggregation_function,])
     # Misuse
     with pytest.raises(ValueError, match="number of aggregation functions must be equal to one or"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels,aggregation_function=[aggregation_function,aggregation_function])                                                    
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels,aggregation_function=[aggregation_function,aggregation_function])                                                    
 
 def break_log_likelihood_functions_with_two_dimensions():
 
@@ -607,7 +607,7 @@ def break_log_likelihood_functions_with_two_dimensions():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(ValueError, match="Shape of np.array containing arguments of the log likelihood function"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
     
     # np.array with too many dimensions
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -617,7 +617,7 @@ def break_log_likelihood_functions_with_two_dimensions():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(ValueError, match="Shape of np.array containing arguments of the log likelihood function"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # np.array with too little dimensions
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -627,7 +627,7 @@ def break_log_likelihood_functions_with_two_dimensions():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(ValueError, match="Shape of np.array containing arguments of the log likelihood function"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
     # float
     # ~~~~~
@@ -637,7 +637,7 @@ def break_log_likelihood_functions_with_two_dimensions():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(TypeError, match="accepted types are np.ndarray and pd.Series"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)    
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)    
 
     # float in a list
     # ~~~~~~~~~~~~~~~
@@ -647,7 +647,7 @@ def break_log_likelihood_functions_with_two_dimensions():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(TypeError, match="accepted types are np.ndarray and pd.Series"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)    
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)    
 
     # list
     # ~~~~
@@ -657,7 +657,7 @@ def break_log_likelihood_functions_with_two_dimensions():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(TypeError, match="accepted types are np.ndarray and pd.Series"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)    
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)    
 
     # np.array placed inside too many lists
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -667,7 +667,7 @@ def break_log_likelihood_functions_with_two_dimensions():
     # Setup objective function without priors and with negative weights 
     with pytest.raises(TypeError, match="accepted types are np.ndarray and pd.Series"):
         log_posterior_probability(model,pars,bounds,data,states,
-                                    log_likelihood_fnc,log_likelihood_fnc_args,-weights,labels=labels)
+                                    log_likelihood_fnc,log_likelihood_fnc_args,weights=-weights,labels=labels)
 
 ##################################################
 ## Model where states have different dimensions ##
@@ -728,4 +728,4 @@ def test_SIR_SI():
     # Vector population --> calibrate to unstratified data
     data=[df.groupby(by=['time','age_groups']).sum(), df.groupby(by=['time']).sum()]
     # Correct use
-    objective_function = log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels,)
+    objective_function = log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights=weights,labels=labels,)

--- a/tutorials/influenza_1718/calibration.py
+++ b/tutorials/influenza_1718/calibration.py
@@ -134,7 +134,6 @@ if __name__ == '__main__':
     # Define dataset
     data=[df_influenza[start_calibration:end_calibration], ]
     states = ["Im_inc",]
-    weights = np.array([1,])
     log_likelihood_fnc = [ll_negative_binomial,]
     log_likelihood_fnc_args = [len(age_groups)*[alpha,],]
     # Calibated parameters and bounds
@@ -142,7 +141,7 @@ if __name__ == '__main__':
     labels = ['$\\beta$', '$f_{ud}$']
     bounds = [(1e-6,0.08), (1e-3,1-1e-3)]
     # Setup objective function (no priors --> uniform priors based on bounds)
-    objective_function = log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,weights,labels=labels)
+    objective_function = log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,labels=labels)
     # Extract expanded bounds and labels
     expanded_labels = objective_function.expanded_labels 
     expanded_bounds = objective_function.expanded_bounds                                   


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

The class `log_posterior_probability()` now has an input argument `start_sim` you can provide upon initialization. Prior, class just sought the earliest start time/date in the provided datasets and used that as the start of the simulations, which is quite limiting. 