### PR TITLE
Refurbish emcee sampler

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -234,7 +234,7 @@
 
 >    **Hyperparameters:**
 >    * **moves** (list) - optional - Algorithm used for updating the coordinates of walkers in an ensemble sampler. By default, pySODM uses a shotgun approach by implementing a balanced cocktail of `emcee` moves. Consult the [emcee documentation](https://emcee.readthedocs.io/en/stable/user/moves/) for an overview of all moves.
->    * **backend** (`emcee.backends.HDFBackend`) - optional - Backend of a previous sampling experiment. If a backend is provided, the sampler is restarted from the last iteration of the previous run. Consult the [emcee documentation](https://emcee.readthedocs.io/en/stable/user/backends/).
+>    * **backend** (str) - optional - Path to backend of a previous sampling run. If a backend is provided, the sampler is restarted from the last iteration of the previous run. Consult the [emcee documentation](https://emcee.readthedocs.io/en/stable/user/backends/).
 >    * **progress** (bool) - optional - Enables the progress bar.
 
 >    **Returns:**

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -161,7 +161,11 @@ def test_correct_approach_wo_dimension():
         sampler = run_EnsembleSampler(pos, n_mcmc, identifier, objective_function, (), {'simulation_kwargs': {'warmup': warmup}},
                                     fig_path=fig_path, samples_path=samples_path, print_n=print_n, backend=None, processes=1, progress=True,
                                     settings_dict=settings)
-        #Generate samples dict
+        # Restart and sample 100 more
+        sampler = run_EnsembleSampler(pos, n_mcmc, identifier, objective_function, (), {'simulation_kwargs': {'warmup': warmup}},
+                                    fig_path=fig_path, samples_path=samples_path, print_n=print_n, backend=samples_path+f'{identifier}_BACKEND_{str(datetime.date.today())}.hdf5', processes=1, progress=True,
+                                    settings_dict=settings)
+        # Generate samples dict
         samples_dict = emcee_sampler_to_dictionary(samples_path, identifier, discard=discard)
 
 def break_stuff_wo_dimension():


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

Added a more descriptive print out when starting a new emcee run or restarting a run.

Restarting a run:

```bash
Markov-Chain Monte-Carlo sampling
=================================

Found existing backend:'/Users/twallema/Documents/academic/github/influenza-USA/scripts/../data/interim/calibration/2017-2018/beta_f_R/../data/interim/calibration/2017-2018/beta_f_R/beta_f_R_BACKEND_2024-09-27.hdf5'

Continuing run
--------------
Iterations: 5 (found 1656 previous iterations)
Parameters: 106
Markov chains: 318
Cores: 16
Printing traceplot and autocorrelation plot every 2 iterations
Traceplot: /Users/twallema/Documents/academic/github/influenza-USA/scripts/../data/interim/calibration/2017-2018/beta_f_R/traceplots/beta_f_R_TRACE_2024-09-28.pdf
Autocorrelation plot: /Users/twallema/Documents/academic/github/influenza-USA/scripts/../data/interim/calibration/2017-2018/beta_f_R/autocorrelation/beta_f_R_AUTOCORR_2024-09-28.pdf
```

Instead of providing an emcee backend object, a string representing the path to the correct backend must be provided to restart a run. This avoids users from needing to figure out how to load an emcee hdf5 backend.