### PR TITLE
Deprecation of "warmup"

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -74,7 +74,7 @@ The parameters of the initial condition function become a part of the model's pa
 
 **Class methods:**
 
-* **sim(time, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='RK23', rtol=1e-3, tau=None, output_timestep=1, warmup=0)**
+* **sim(time, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='RK23', rtol=1e-3, tau=None, output_timestep=1)**
 
     Integrate a pySODM model using `scipy.integrate.solve_ivp()`. Can optionally perform `N` repeated simulations. Can change the values of model parameters at every consecutive simulation by manipulating the dictionary of model parameters `parameters` using a `draw_function`.
 
@@ -97,8 +97,6 @@ The parameters of the initial condition function become a part of the model's pa
     * **tau** - (int/float) - optional - If `tau != None`, the model is simulated using a simple discrete timestepper with fixed timestep `tau`. Overrides the `method` and `rtol` arguments. 
 
     * **output_timestep** - (int/float) - optional - Interpolate model output to every `output_timestep` timesteps.
-
-    * **warmup** - (float) - optional - Number of days to simulate prior to the simulation start. Usefull in epidemiological contexts when the time between the appearance of "patient zero" and the collection of data is be estimated. 
 
     **Returns**
 
@@ -185,7 +183,7 @@ The parameters of the initial condition function become a part of the model's pa
 
 **Methods:**
 
-* **sim(time, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='tau_leap', tau=0.5, output_timestep=1, warmup=0)**
+* **sim(time, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='tau_leap', tau=0.5, output_timestep=1)**
 
     Integrate a model stochastically using Gillespie's Stochastic Simulation Algorithm (SSA) or the approximate Tau-leaping method. Can optionally perform `N` repeated simulations. Can change the values of model parameters at every consecutive simulation by manipulating the dictionary of model parameters `parameters` using a `draw_function`.
 
@@ -205,8 +203,6 @@ The parameters of the initial condition function become a part of the model's pa
     * **tau** - (int/float) - optional - Leap value of the tau-leaping method. Consult the following [blog](https://lewiscoleblog.com/gillespie-algorithm) for more background information.
 
     * **output_timestep** - (int/float) - optional - Interpolate model output to every `output_timestep` timesteps. For datetimes: expressed in days.
-
-    * **warmup** - (float) - optional - Number of days to simulate prior to the simulation start. Usefull in epidemiological contexts when the time between the appearance of "patient zero" and the collection of data is be estimated. 
 
     **Returns**
 

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -317,7 +317,6 @@ Samples path, identifier and run_date are combined to find the right .hdf5 `emce
 >    * **thetas** (list or 1D np.ndarray) - A list with values of model parameters. Values ordermust correspond to the order of `parameter_names`
 
 >    **Returns:**
->    * **warmup** (float) - Offset between simulation start and start of data collection. Because 'warmup' does not reside in the model parameters dictionary, this argument is only returned if 'warmup' is in the parameter name list 'pars'
 >    * **param_dict** (dict) - Model parameters dictionary with values of parameters `parameter_names` set to the values listed in `thetas`
 
 ***function* variance_analysis(data, resample_frequency)**

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -403,7 +403,7 @@ class JumpProcess:
         # simulate model
         return self._sim_single(time, actual_start_date, method, tau, output_timestep)
 
-    def sim(self, time, warmup=0, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='tau_leap', tau=1, output_timestep=1):
+    def sim(self, time, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='tau_leap', tau=1, output_timestep=1):
 
         """
         Simulate a model during a given time period.
@@ -417,9 +417,6 @@ class JumpProcess:
             1) Input is converted to [0, time]. Floats are automatically rounded.
             2) Input is interpreted as [start_time, stop_time]. Time axis in xarray output is named 'time'. Floats are automatically rounded.
             3) Input is interpreted as [start_date, stop_date]. Time axis in xarray output is named 'date'. Floats are automatically rounded.
-
-        warmup : int
-            Number of days to simulate prior to start time or date
 
         N : int
             Number of repeated simulations (default: 1)
@@ -454,7 +451,7 @@ class JumpProcess:
         # Input checks on solution settings
         validate_solution_methods_JumpProcess(method, tau)
         # Input checks on supplied simulation time
-        time, actual_start_date = validate_simulation_time(time, warmup)
+        time, actual_start_date = validate_simulation_time(time)
         # Input checks related to draw functions
         if draw_function:
             # validate function
@@ -729,7 +726,7 @@ class ODE:
         out = self._sim_single(time, actual_start_date, method, rtol, output_timestep, tau)
         return out
 
-    def sim(self, time, warmup=0, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='RK23', rtol=1e-4, tau=None, output_timestep=1):
+    def sim(self, time, N=1, draw_function=None, draw_function_kwargs={}, processes=None, method='RK23', rtol=1e-4, tau=None, output_timestep=1):
         """
         Simulate a model during a given time period.
         Can optionally perform `N` repeated simulations with sampling of model parameters using a function `draw_function`.
@@ -743,9 +740,6 @@ class ODE:
             1) Input is converted to [0, time]. Floats are automatically rounded.
             2) Input is interpreted as [start_time, stop_time]. Time axis in xarray output is named 'time'. Floats are automatically rounded.
             3) Input is interpreted as [start_date, stop_date]. Time axis in xarray output is named 'date'. Floats are automatically rounded.
-
-        warmup : int
-            Number of days to simulate prior to start time or date
 
         N : int
             Number of repeated simulations (default: 1)
@@ -783,8 +777,8 @@ class ODE:
         # Input checks on solution settings
         validate_solution_methods_ODE(rtol, method, tau)
         # Input checks on supplied simulation time
-        time, actual_start_date = validate_simulation_time(time, warmup)
-        # Input checks related to draw functions
+        time, actual_start_date = validate_simulation_time(time)
+        # Input checks on draw functions
         if draw_function:
             # validate function
             validate_draw_function(draw_function, draw_function_kwargs, copy.deepcopy(self.parameters), copy.deepcopy(self.initial_states), self.state_shapes)

--- a/src/pySODM/models/validation.py
+++ b/src/pySODM/models/validation.py
@@ -6,19 +6,18 @@ from collections import OrderedDict
 
 def date_to_diff(actual_start_date, end_date):
     """
-    Convert date string to int (i.e. number of days since day 0 of simulation,
-    which is warmup days before actual_start_date)
+    Convert date string to int (i.e. number of days since day 0 of simulation)
     """
     return float((end_date-actual_start_date)/timedelta(days=1))
 
-def validate_simulation_time(time, warmup):
+def validate_simulation_time(time):
     """Validates the simulation time of the sim() function. Various input types are converted to: time = [start_float, stop_float]"""
 
     actual_start_date=None
     if isinstance(time, float):
-        time = [0-warmup, round(time)]
+        time = [0, round(time)]
     elif isinstance(time, int):
-        time = [0-warmup, time]
+        time = [0, time]
     elif isinstance(time, list):
         if not len(time) == 2:
             raise ValueError(f"wrong length of list-like simulation start and stop (length: {len(time)}). correct format: time=[start, stop] (length: 2).")
@@ -26,15 +25,14 @@ def validate_simulation_time(time, warmup):
             # If they are all int or flat (or commonly occuring np.int64/np.float64)
             if all([isinstance(item, (int,float,np.int32,np.float32,np.int64,np.float64)) for item in time]):
                 time = [round(item) for item in time]
-                time[0] -= warmup
             # If they are all datetime
             elif all([isinstance(item, datetime) for item in time]):
-                actual_start_date = time[0] - timedelta(days=warmup)
+                actual_start_date = time[0]
                 time = [0, date_to_diff(actual_start_date, time[1])]
             # If they are all strings: assume format is YYYY-MM-DD and convert to a datetime
             elif all([isinstance(item, str) for item in time]):
                 time = [datetime.strptime(item,"%Y-%m-%d") for item in time]
-                actual_start_date = time[0] - timedelta(days=warmup)
+                actual_start_date = time[0]
                 time = [0, date_to_diff(actual_start_date, time[1])]
             else:
                 types = [type(t) for t in time]

--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -475,11 +475,6 @@ class log_posterior_probability():
         # Unflatten thetas
         thetas_dict = list_to_dict(thetas, self.parameter_shapes, retain_floats=True)
 
-        # Assign and remove warmup
-        if 'warmup' in thetas_dict.keys():
-            simulation_kwargs.update({'warmup': float(thetas_dict['warmup'])})
-            del thetas_dict['warmup']
-
         # Assign model parameters
         self.model.parameters.update(thetas_dict)
 
@@ -699,8 +694,7 @@ def validate_calibrated_parameters(parameters_function, parameters_model):
     """
     Validates the parameters the user wants to calibrate. Parameters must: 1) Be valid model parameters, 2) Have one value, or, have multiple values (list or np.ndarray).
     Construct a dictionary containing the parameter names as key and their sizes (type: tuple) as values.
-    An exception is coded for 'warmup' (= number of days between data and simulation start)
-   
+
     Parameters
     ----------
 
@@ -724,13 +718,10 @@ def validate_calibrated_parameters(parameters_function, parameters_model):
     parameters_shapes = []
     for param_name in parameters_function:
         # Check if the parameter exists
-        if ((param_name not in parameters_model)&(param_name!='warmup')):
+        if param_name not in parameters_model:
             raise Exception(
                 f"To be calibrated model parameter '{param_name}' is not a valid model parameter!"
             )
-        elif param_name == 'warmup':
-            parameters_shapes.append((1,))
-            parameters_sizes.append(1)
         else:
             # Check the datatype: only int, float, list of int/float, np.array
             if isinstance(parameters_model[param_name], bool):

--- a/src/pySODM/optimization/utils.py
+++ b/src/pySODM/optimization/utils.py
@@ -103,31 +103,16 @@ def assign_theta(param_dict, parameter_names, thetas):
 
     Returns
     -------
-    warmup : int
-        Offset between simulation start and start of data collection
-        Because 'warmup' does not reside in the model parameters dictionary, this argument is only returned if 'warmup' is in the parameter name list 'pars'
 
     param_dict : dict
         Model parameters dictionary with values of parameters 'pars' set to the obtained PSO estimate in vector 'theta'
 
     """
 
-    # Find out if 'warmup' needs to be estimated
-    warmup_position = None
-    if 'warmup' in parameter_names:
-        warmup_position = parameter_names.index('warmup')
-        warmup = thetas[warmup_position]
-        parameter_names = [x for x in parameter_names if x != "warmup"]
-        thetas = [x for (i, x) in enumerate(thetas) if i != warmup_position]
-
     thetas_dict, n = _thetas_to_thetas_dict(thetas, parameter_names, param_dict)
     for i, (param, value) in enumerate(thetas_dict.items()):
         param_dict.update({param: value})
-
-    if warmup_position:
-        return warmup, param_dict
-    else:
-        return param_dict
+    return param_dict
 
 def _thetas_to_thetas_dict(thetas, parameter_names, model_parameter_dictionary):
     """

--- a/src/tests/test_JumpProcess.py
+++ b/src/tests/test_JumpProcess.py
@@ -640,11 +640,6 @@ def break_ICF():
     with pytest.raises(ValueError, match="The desired shape of model state"):
         model = SIR(set_initial_condition, parameters)
 
-test_ICF()
-test_ICF_args()
-test_ICF_TDPF()
-break_ICF()
-
 ####################
 ## Draw functions ##
 ####################
@@ -802,3 +797,24 @@ def test_draw_function():
     output = model.sim(time, draw_function_kwargs={'arg_1': 0}, N=100)
     # assert dimension 'draws' is present in output
     assert 'draws' in list(output.sizes.keys())
+
+########################
+## Call all functions ##
+########################
+
+test_SIR_time()
+test_SIR_date()
+test_SSA()
+test_model_init_validation()
+test_stratified_SIR_output_shape()
+test_stratified_SIR_automatic_filling_initial_states()
+test_model_stratified_init_validation()
+test_SIR_SI_state_shapes()
+test_SIR_SI_automatic_filling_initial_states()
+test_TDPF_stratified()
+test_TDPF_nonstratified()
+test_ICF()
+test_ICF_args()
+test_ICF_TDPF()
+break_ICF()
+test_draw_function()

--- a/src/tests/test_ODE.py
+++ b/src/tests/test_ODE.py
@@ -306,7 +306,6 @@ def test_stratified_SIR_init_validation():
 
     assert model.initial_states == initial_states
     assert model.parameters == parameters
-    assert model.parameters_stratified_names == ['beta']
     assert model.states_names == ['S', 'I', 'R']
     assert model.parameters_names == ['gamma']
 
@@ -636,11 +635,6 @@ def break_ICF():
     with pytest.raises(ValueError, match="The desired shape of model state"):
         model = SIR(set_initial_condition, parameters)
 
-test_ICF()
-test_ICF_args()
-test_ICF_TDPF()
-break_ICF()
-
 ####################
 ## Draw functions ##
 ####################
@@ -787,3 +781,24 @@ def test_draw_function():
     # or
     with pytest.raises(ValueError, match="attempting to perform N=100 repeated simulations without using a draw function"):
         model.sim(time, draw_function_kwargs={'arg_1': 0}, N=100)
+
+########################
+## Call all functions ##
+########################
+
+test_SIR_time()
+test_SIR_date()
+test_SIR_discrete_stepper()
+test_model_init_validation()
+test_stratified_SIR_output_shape()
+test_stratified_SIR_automatic_filling_initial_states()
+test_stratified_SIR_init_validation()
+test_SIR_SI_state_shapes()
+test_SIR_SI_automatic_filling_initial_states()
+test_TDPF_stratified()
+test_TDPF_nonstratified()
+test_ICF()
+test_ICF_args()
+test_ICF_TDPF()
+break_ICF()
+test_draw_function()

--- a/src/tests/test_calibration.py
+++ b/src/tests/test_calibration.py
@@ -753,3 +753,22 @@ def test_SIR_SI():
     data=[df.groupby(by=['time','age_groups']).sum(), df.groupby(by=['time']).sum()]
     # Correct use
     objective_function = log_posterior_probability(model,pars,bounds,data,states,log_likelihood_fnc,log_likelihood_fnc_args,start_sim=start_sim,weights=weights,labels=labels,)
+
+########################
+## Call all functions ##
+########################
+
+test_weights()
+test_start_sim()
+test_correct_approach_wo_dimension()
+break_stuff_wo_dimension()
+break_log_likelihood_functions_wo_dimension()
+test_xarray_datasets()
+test_calibration_nd_parameter()
+test_correct_approach_with_one_dimension_0()
+break_stuff_with_one_dimension()
+break_log_likelihood_functions_with_one_dimension()
+test_correct_approach_with_two_dimensions()
+test_aggregation_function()
+break_log_likelihood_functions_with_two_dimensions()
+test_SIR_SI()

--- a/tutorials/influenza_1718/calibration.py
+++ b/tutorials/influenza_1718/calibration.py
@@ -197,7 +197,7 @@ if __name__ == '__main__':
     settings={'start_calibration': start_calibration, 'end_calibration': end_calibration,
               'n_chains': nwalkers, 'starting_estimate': list(theta), 'labels': expanded_labels, 'tau': tau}
     # Sample n_mcmc iterations
-    sampler = run_EnsembleSampler(pos, n_mcmc, identifier, objective_function,  objective_function_kwargs={'simulation_kwargs': {'warmup': 0, 'tau':tau}},
+    sampler = run_EnsembleSampler(pos, n_mcmc, identifier, objective_function,  objective_function_kwargs={'simulation_kwargs': {'tau':tau}},
                                     fig_path=fig_path, samples_path=samples_path, print_n=print_n, backend=None, processes=processes, progress=True,
                                     settings_dict=settings)                                                                               
     # Generate a sample dictionary and save it as .json for long-term storage


### PR DESCRIPTION
<!-- Please check if the PR fulfills these requirements. Put an `x` in all the boxes that apply: -->
* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have updated the documentation accordingly.

Describe your fixes/additions/changes

## What was warmup?

"warmup" was a legacy feature from the COVID-19 pandemic, it was a parameter (int/float or date) that could be given to the sim function, allowing the simulation to start prior to the start date. Its value could be calibrated to determine when an epidemic was seeded. 

It has persisted until now because it didn't harm anyone.

## Why remove warmup?

- PR #99 can be used instead. Users wanting to use this epi-legacy-feature can just infer the initial number of infected in their epi models to find similar results.
- To keep the code clean and as easily accessible as possible.