### PR TITLE
Function perturbate_theta: description of output dimensions was reversed

### DIFF
--- a/src/pySODM/optimization/mcmc.py
+++ b/src/pySODM/optimization/mcmc.py
@@ -213,7 +213,7 @@ def perturbate_theta(theta, pert, multiplier=2, bounds=None, verbose=None):
         Number of chains
 
     pos : np.array
-        Initial positions for markov chains. Dimensions: [ndim, nwalkers]
+        Initial positions for markov chains. Dimensions: [nwalkers, ndim]
     """
 
     # Validation


### PR DESCRIPTION
**Pull request checklist**

* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have verified all tests work / have added new tests.
* [ ] I have verified all tutorials work.
* [ ] I have updated the documentation accordingly.

**Describe your pull request**

In `src/pySODM/optimization/mcmc.py` lives a function `perturbate_theta`, the description of the dimension of its output `pos` was incorrect. 