### PR TITLE
Use of unbounded informative prior conflicts with restricting estimated pars within bounds

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -466,11 +466,15 @@ class log_posterior_probability():
         lp = self.compute_log_prior_probability(thetas, self.log_prior_prob_fnc, self.log_prior_prob_fnc_args)
 
         # Restrict thetas to user-provided bounds
+        # --> going outside can crash a model!
+        # this enforces a uniform prior within bounds
         for i,theta in enumerate(thetas):
             if theta > self.expanded_bounds[i][1]:
                 thetas[i] = self.expanded_bounds[i][1]
+                lp += - np.inf
             elif theta < self.expanded_bounds[i][0]:
                 thetas[i] = self.expanded_bounds[i][0]
+                lp += - np.inf
 
         # Unflatten thetas
         thetas_dict = list_to_dict(thetas, self.parameter_shapes, retain_floats=True)


### PR DESCRIPTION
**Pull request checklist**

* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have verified all tests work / have added new tests.
* [ ] I have verified all tutorials work.
* [ ] I have updated the documentation accordingly.

**Describe your pull request**

When using an unbounded prior distribution (f.i normal), a suggestion of the parameter value outside the user-provided bounds by the optimization algorithm would result in a non-infinite log likelihood score and the parameter being corrected to fall within the bounds. This can create a situation where a physical bound of the system, enforced by the user through the bounds, is not "recognized" by the optimization algorithm. 

This PR makes sure that the user-provided bounds function as a uniform prior, any suggestion outside the bounds results in a log likelihood equal to infinity, and this user-provided bounds / uniform prior dominates any informative prior. 