### PR TITLE
Resolve no output error when providing expanded prior functions and arguments

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -856,6 +856,10 @@ def validate_expand_log_prior_prob(log_prior_prob_fnc, log_prior_prob_fnc_args, 
                     for _ in range(parameter_sizes[name]):
                         expanded_log_prior_prob_fnc.append(log_prior_prob_fnc[i])
                         expanded_log_prior_prob_fnc_args.append(log_prior_prob_fnc_args[i])
+        else:
+            # No expansion needed
+            expanded_log_prior_prob_fnc = log_prior_prob_fnc
+            expanded_log_prior_prob_fnc_args = log_prior_prob_fnc_args
 
     return expanded_log_prior_prob_fnc, expanded_log_prior_prob_fnc_args
 


### PR DESCRIPTION
**Pull request checklist**

* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [NA] I have verified all tests work / have added new tests.
* [ NA] I have verified all tutorials work.
* [ NA] I have updated the documentation accordingly.

**Describe your pull request**

Turns out, if you have 1D parameter you're calibrating, and you provide the expanded number of prior functions and arguments to the objective function, this results in the following error:

```bash
Traceback (most recent call last):
  File "/Users/twallema/Documents/academic/github/influenza-USA/scripts/SIR_SequentialTwoStrain_stateSlice/calibrate_incremental-SIR_SequentialTwoStrain.py", line 170, in <module>
    objective_function = log_posterior_probability(model, pars, bounds, data, states, log_likelihood_fnc, log_likelihood_fnc_args,
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/twallema/Documents/academic/github/pySODM/src/pySODM/optimization/objective_functions.py", line 388, in __init__
    self.log_prior_prob_fnc, self.log_prior_prob_fnc_args = validate_expand_log_prior_prob(log_prior_prob_fnc, log_prior_prob_fnc_args, parameter_sizes, self.expanded_bounds)
                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/twallema/Documents/academic/github/pySODM/src/pySODM/optimization/objective_functions.py", line 885, in validate_expand_log_prior_prob
    return expanded_log_prior_prob_fnc, expanded_log_prior_prob_fnc_args
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'expanded_log_prior_prob_fnc' where it is not associated with a value
```

No output was made.