### PR TITLE
Bugfix validation of calibrated parameters

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -720,6 +720,7 @@ def validate_simulation_time_lpp(start_sim, time_index, data):
 
     return start_sim, end_sim
 
+
 def validate_calibrated_parameters(parameters_function, parameters_model):
     """
     Validates the parameters the user wants to calibrate. Parameters must: 1) Be valid model parameters, 2) Have one value, or, have multiple values (list or np.ndarray).
@@ -743,7 +744,7 @@ def validate_calibrated_parameters(parameters_function, parameters_model):
     parameters_shapes: dict
         Dictionary containing the shape of every model parameter.    
     """
-
+    
     parameters_sizes = []
     parameters_shapes = []
     for param_name in parameters_function:
@@ -756,9 +757,9 @@ def validate_calibrated_parameters(parameters_function, parameters_model):
             # Check the datatype: only int, float, list of int/float, np.array
             if isinstance(parameters_model[param_name], bool):
                 raise TypeError(
-                        f"pySODM supports the calibration of model parameters of type int, float, list (containing int/float) or 1D np.ndarray. Model parameter '{param_name}' is of type '{type(model.parameters[param_name])}'"
+                        f"pySODM supports the calibration of model parameters of type int, float, list (containing int/float) or 1D np.ndarray. Model parameter '{param_name}' is of type '{type(parameters_model[param_name])}'"
                     )
-            elif isinstance(parameters_model[param_name], (int,float)):
+            elif isinstance(parameters_model[param_name], (int,float,np.int32,np.int64,np.float32,np.float64)):
                 parameters_shapes.append((1,))
                 parameters_sizes.append(1)
             elif isinstance(parameters_model[param_name], np.ndarray):
@@ -774,10 +775,11 @@ def validate_calibrated_parameters(parameters_function, parameters_model):
                     parameters_shapes.append(np.array(parameters_model[param_name]).size)
             else:
                 raise TypeError(
-                        f"pySODM supports the calibration of model parameters of type int, float, list (containing int/float) or 1D np.ndarray. Model parameter '{param_name}' is of type '{type(model.parameters[param_name])}'"
+                        f"pySODM supports the calibration of model parameters of type int, float, list (containing int/float) or 1D np.ndarray. Model parameter '{param_name}' is of type '{type(parameters_model[param_name])}'"
                         )
 
     return dict(zip(parameters_function, parameters_sizes)), dict(zip(parameters_function, parameters_shapes))
+
 
 def expand_pars_bounds_labels(parameter_shapes, parameter_sizes, bounds, labels):
     """

--- a/src/pySODM/optimization/utils.py
+++ b/src/pySODM/optimization/utils.py
@@ -114,7 +114,7 @@ def assign_theta(param_dict, parameter_names, thetas):
 
     _, parameter_shapes = validate_calibrated_parameters(parameter_names, param_dict)
     thetas_dict = list_to_dict(np.array(thetas), parameter_shapes, retain_floats=True)
-    for i, (param, value) in enumerate(thetas_dict.items()):
+    for _, (param, value) in enumerate(thetas_dict.items()):
         param_dict.update({param: value})
     return param_dict
 


### PR DESCRIPTION
**Pull request checklist**

* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have verified all tests work / have added new tests.
* [NA] I have verified all tutorials work.
* [NA] I have updated the documentation accordingly.

**Describe your pull request**

In the `log_posterior_probability` class, it it checked that calibrated model parameters are either int, float, list or a numpy array. However, when this is not the case, an error is thrown, but in this error a faulty reference to the model object is made. Further, np.int64/np.int32 or np.foat64/np.float32 are also allowed but not tested.