### PR TITLE
Force printing on cluster

### DIFF
--- a/src/pySODM/optimization/nelder_mead.py
+++ b/src/pySODM/optimization/nelder_mead.py
@@ -114,7 +114,8 @@ def optimize(
     print(f'For {max_iter} iterations using {processes} cores')
     print(f'Starting point: {x_start}')
     print(f'Bounds: {bounds}\n')
-
+    sys.stdout.flush()
+    
     # Compute score of initial estimate
     dim = len(x_start)
     prev_best = obj(x_start)

--- a/src/pySODM/optimization/nelder_mead.py
+++ b/src/pySODM/optimization/nelder_mead.py
@@ -1,3 +1,4 @@
+import sys
 import copy
 import numpy as np
 import multiprocessing as mp
@@ -174,6 +175,8 @@ def optimize(
         if no_improv >= no_improv_break:
             print('Maximum number of iterations without improvement reached. Quitting.\n')
             return res[0][0], res[0][1]
+        # Force printing on clusters
+        sys.stdout.flush()
 
         ################
         ## Reflection ##

--- a/src/pySODM/optimization/pso.py
+++ b/src/pySODM/optimization/pso.py
@@ -122,7 +122,6 @@ def optimize(
 
     print(f'\nParticle Swarm minimization')
     print(f'===========================\n')
-
     print(f'Using {processes} cores')
     
     # Check for constraint function(s) #########################################
@@ -146,6 +145,8 @@ def optimize(
     is_feasible = partial(_is_feasible_wrapper, cons)
 
     print(f'Using the following bounds: {bounds}\n')
+    # force printout on clusters
+    sys.stdout.flush()
 
     # Initialize the multiprocessing module if necessary
     if processes > 1:


### PR DESCRIPTION
**Pull request checklist**

* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have verified all tests work / have added new tests.
* [ ] I have verified all tutorials work.
* [ ] I have updated the documentation accordingly.

**Describe your pull request**

The Nelder-Mead wasn't "forced" to printout its output on a cluster using `sys.stdout.flush()`, this is now the case.