### PR TITLE
add a test on settings_dict to make sure user doesn't get error when …

### DIFF
--- a/tutorials/SIR/workflow_tutorial.py
+++ b/tutorials/SIR/workflow_tutorial.py
@@ -137,7 +137,7 @@ if __name__ == '__main__':
     n_mcmc = 400
     multiplier_mcmc = 9
     processes = 9
-    print_n = 50
+    print_n = 100
     discard = 50
     samples_path = 'sampler_output/'
     fig_path = 'sampler_output/'
@@ -146,7 +146,7 @@ if __name__ == '__main__':
     ndim, nwalkers, pos = perturbate_theta(theta, pert=[0.10,], multiplier=multiplier_mcmc, bounds=bounds)
     # Write some usefull settings to a pickle file (no pd.Timestamps or np.arrays allowed!)
     settings={'start_calibration': start_date.strftime("%Y-%m-%d"), 'end_calibration': end_date.strftime("%Y-%m-%d"),
-              'starting_estimate': list(theta)}
+              'starting_estimate': theta}
     # Sample
     sampler, samples_xr = run_EnsembleSampler(pos, n_mcmc, identifier, objective_function,
                                                 fig_path=fig_path, samples_path=samples_path, print_n=print_n,


### PR DESCRIPTION
…exporting to netcdf later

**Pull request checklist**

* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have verified all tests work / have added new tests.
* [ ] I have verified all tutorials work.
* [ ] I have updated the documentation accordingly.

**Describe your pull request**

To be able to export an xarray to a netCDF file during sampling, the allowed types in the attributes of the xarray can only be (scalar) int, float, str, bool, (array-like) homogeneous list of int, float, str or bool OR 1D numpy array containing only int or float.

An input check is added to to the sampling function to verify the types supplied in `settings_dict={}` meet these requirements, therein avoiding any upstream errors when calling `_dump_sampler_to_xarray()`.

