### PR TITLE
Retain dates in integrate function

### DIFF
--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -746,18 +746,23 @@ class ODE:
 
             states = list_to_dict(y, self.state_shapes)
 
+            # --------------------------------------------
+            # Reconstruct datetime simtime (if applicable)
+            # --------------------------------------------
+
+            if actual_start_date is not None:
+                # datetime simtime
+                date = int_to_date(actual_start_date, t)
+            else:
+                # integer simtime
+                date = t
+
             # --------------------------------------
             # update time-dependent parameter values
             # --------------------------------------
 
             params = pars.copy()
-
             if self.time_dependent_parameters:
-                if actual_start_date is not None:
-                    date = int_to_date(actual_start_date, t)
-                    t = datetime.timestamp(date)
-                else:
-                    date = t
                 for i, (param, param_func) in enumerate(self.time_dependent_parameters.items()):
                     func_params = {key: params[key] for key in self._function_parameters[i]}
                     params[param] = param_func(date, states, pars[param], **func_params)
@@ -772,7 +777,7 @@ class ODE:
             # perform integration
             # -------------------
 
-            dstates = self.integrate(t, **states, **params)
+            dstates = self.integrate(date, **states, **params)
 
             # -------
             # Flatten

--- a/src/pySODM/models/base.py
+++ b/src/pySODM/models/base.py
@@ -358,18 +358,23 @@ class JumpProcess:
 
                 states = list_to_dict(y, self.state_shapes, retain_floats=False)
 
+                # --------------------------------------------
+                # Reconstruct datetime simtime (if applicable)
+                # --------------------------------------------
+
+                if actual_start_date is not None:
+                    # datetime simtime
+                    date = int_to_date(actual_start_date, t)
+                else:
+                    # integer simtime
+                    date = t
+
                 # --------------------------------------
                 # update time-dependent parameter values
                 # --------------------------------------
 
                 params = pars.copy()
-
                 if self.time_dependent_parameters:
-                    if actual_start_date is not None:
-                        date = int_to_date(actual_start_date, t)
-                        t = datetime.timestamp(date)
-                    else:
-                        date = t
                     for i, (param, param_func) in enumerate(self.time_dependent_parameters.items()):
                         func_params = {key: params[key] for key in self._function_parameters[i]}
                         params[param] = param_func(date, states, pars[param], **func_params)
@@ -384,7 +389,7 @@ class JumpProcess:
                 # compute rates
                 # -------------
 
-                rates = self.compute_rates(t, **states, **params)
+                rates = self.compute_rates(date, **states, **params)
 
                 # --------------
                 # Gillespie step

--- a/tutorials/SIR/workflow_tutorial.py
+++ b/tutorials/SIR/workflow_tutorial.py
@@ -56,6 +56,8 @@ class ODE_SIR(ODE):
 
     @staticmethod
     def integrate(t, S, I, R, beta, gamma):
+
+        print(t)
         
         # Calculate total population
         N = S+I+R
@@ -70,7 +72,11 @@ class ODE_SIR(ODE):
 model = ODE_SIR(initial_states={'S': 1000, 'I': 1}, parameters={'beta':0.35, 'gamma':5})
 
 # Simulate from t=0 until t=121
-out = model.sim([0, 121])
+#out = model.sim([0, 121])
+from datetime import datetime
+out = model.sim([datetime(2020,1,1), datetime(2020,2,1)])
+import sys
+sys.exit()
 
 # Is equivalent to:
 out = model.sim(121)

--- a/tutorials/SIR/workflow_tutorial.py
+++ b/tutorials/SIR/workflow_tutorial.py
@@ -57,8 +57,6 @@ class ODE_SIR(ODE):
     @staticmethod
     def integrate(t, S, I, R, beta, gamma):
 
-        print(t)
-        
         # Calculate total population
         N = S+I+R
         # Calculate differentials
@@ -72,11 +70,7 @@ class ODE_SIR(ODE):
 model = ODE_SIR(initial_states={'S': 1000, 'I': 1}, parameters={'beta':0.35, 'gamma':5})
 
 # Simulate from t=0 until t=121
-#out = model.sim([0, 121])
-from datetime import datetime
-out = model.sim([datetime(2020,1,1), datetime(2020,2,1)])
-import sys
-sys.exit()
+out = model.sim([0, 121])
 
 # Is equivalent to:
 out = model.sim(121)


### PR DESCRIPTION
**Pull request checklist**

* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [ ] I have verified all tests work / have added new tests.
* [ ] I have verified all tutorials work.
* [ ] I have updated the documentation accordingly.

**Describe your pull request**

When using datetimes as the simulation timestep, the `t` in a TDPF became a date but not in the `integrate`/`compute_rates` function. From now on, when using a datetime timestep,

```python
# Define the model equations
class ODE_SIR(ODE):
    """
    An SIR model
    """
    
    states = ['S','I','R']
    parameters = ['beta','gamma']

    @staticmethod
    def integrate(t, S, I, R, beta, gamma):
        
        print(t)
        # Calculate total population
        N = S+I+R
        # Calculate differentials
        dS = -beta*S*I/N
        dI = beta*S*I/N - 1/gamma*I
        dR = 1/gamma*I

        return dS, dI, dR
```

The `t` that winds up in the `integrate`/`compute_rates' functions is a datetime.