### PR TITLE
Fix a bug in validate_calibrated_parameters

### DIFF
--- a/src/pySODM/optimization/objective_functions.py
+++ b/src/pySODM/optimization/objective_functions.py
@@ -880,12 +880,12 @@ def validate_calibrated_parameters(parameters_function, parameters_model):
                     )
                 else:
                     parameters_shapes.append(np.array(parameters_model[param_name]).shape)
-                    parameters_shapes.append(np.array(parameters_model[param_name]).size)
+                    parameters_sizes.append(np.array(parameters_model[param_name]).size)
             else:
                 raise TypeError(
                         f"pySODM supports the calibration of model parameters of type int, float, list (containing int/float) or 1D np.ndarray. Model parameter '{param_name}' is of type '{type(parameters_model[param_name])}'"
                         )
-
+        #print(param_name, parameters_shapes)
     return dict(zip(parameters_function, parameters_sizes)), dict(zip(parameters_function, parameters_shapes))
 
 


### PR DESCRIPTION
**Pull request checklist**

* [x] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change
* [x] I have verified all tests work / have added new tests.
* [NA] I have verified all tutorials work.
* [NA] I have updated the documentation accordingly.

**Describe your pull request**

In `validate_calibrated_parameters`, when a parameter is a list,

```python
            ...
            elif isinstance(parameters_model[param_name], list):
                if not all([isinstance(item, (int,float)) for item in parameters_model[param_name]]):
                    raise TypeError(
                        f"To be calibrated model parameter '{param_name}' of type list must only contain int or float!"
                    )
                else:
                    parameters_shapes.append(np.array(parameters_model[param_name]).shape)
                    parameters_shapes.append(np.array(parameters_model[param_name]).size)
```

You can see both size and shape were attached to the variable `parameters_shapes` while the shape should be attached to `parameters_shapes` and the size to `parameters_sizes`.
